### PR TITLE
feat(ci/cd): add CI/CD pipeline and enhance app testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       MONGO_DB_PASSWORD: ${{ secrets.MONGO_DB_PASSWORD }}
       SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
       SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
+    outputs:
+      coverage_exists: ${{ steps.check-backend-coverage.outputs.coverage_exists }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -57,8 +59,17 @@ jobs:
           pytest backend -q --maxfail=1 --disable-warnings
           pytest backend --cov=backend --cov-report=xml
 
+      - name: Check backend coverage file exists
+        id: check-backend-coverage
+        run: |
+          if [ -f backend/coverage.xml ]; then
+            echo "::set-output name=coverage_exists::true"
+          else
+            echo "::set-output name=coverage_exists::false"
+          fi
+
       - name: Upload backend coverage
-        if: always()
+        if: steps.check-backend-coverage.outputs.coverage_exists == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: backend-coverage-report
@@ -68,6 +79,8 @@ jobs:
     name: 🌐 Frontend Build & Test
     runs-on: ubuntu-latest
     needs: formatting
+    outputs:
+      coverage_exists: ${{ steps.check-frontend-coverage.outputs.coverage_exists }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -86,8 +99,17 @@ jobs:
       - name: Generate frontend coverage
         run: npm --prefix frontend run test:coverage -- --coverageReporters=lcov
 
+      - name: Check frontend coverage directory exists
+        id: check-frontend-coverage
+        run: |
+          if [ -d frontend/coverage/lcov-report ] && [ "$(ls -A frontend/coverage/lcov-report)" ]; then
+            echo "::set-output name=coverage_exists::true"
+          else
+            echo "::set-output name=coverage_exists::false"
+          fi
+
       - name: Upload frontend coverage
-        if: always()
+        if: steps.check-frontend-coverage.outputs.coverage_exists == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: frontend-coverage-report
@@ -101,28 +123,18 @@ jobs:
       - frontend-tests
     steps:
       - name: Download backend coverage
+        if: needs.backend-tests.outputs.coverage_exists == 'true'
         uses: actions/download-artifact@v4
         with:
           name: backend-coverage-report
           path: ./reports/backend
-        continue-on-error: true
-
-      - name: Warn if backend coverage missing
-        if: failure()
-        run: |
-          echo "⚠️ backend coverage artifact not available, skipping."
 
       - name: Download frontend coverage
+        if: needs.frontend-tests.outputs.coverage_exists == 'true'
         uses: actions/download-artifact@v4
         with:
           name: frontend-coverage-report
           path: ./reports/frontend
-        continue-on-error: true
-
-      - name: Warn if frontend coverage missing
-        if: failure()
-        run: |
-          echo "⚠️ frontend coverage artifact not available, skipping."
 
       - name: Archive combined coverage
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,9 @@ jobs:
         id: check-backend-coverage
         run: |
           if [ -f backend/coverage.xml ]; then
-            echo "::set-output name=coverage_exists::true"
+            echo "coverage_exists=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=coverage_exists::false"
+            echo "coverage_exists=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Upload backend coverage
@@ -103,9 +103,9 @@ jobs:
         id: check-frontend-coverage
         run: |
           if [ -d frontend/coverage/lcov-report ] && [ "$(ls -A frontend/coverage/lcov-report)" ]; then
-            echo "::set-output name=coverage_exists::true"
+            echo "coverage_exists=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=coverage_exists::false"
+            echo "coverage_exists=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Upload frontend coverage


### PR DESCRIPTION
## SUMMARY

This PR updates the existing GitHub Actions workflow to add existence checks around coverage artifacts so that upload/download steps are only run when the files or directories actually exist. By gating the `upload-artifact` steps in `backend-tests` and `frontend-tests` on the presence of the coverage report, and gating the corresponding `download-artifact` steps in the `coverage` job on those same flags, we eliminate the spurious “artifact not found” and “no files were found” errors and warnings.

## TEST PLAN

1. **No coverage present**  
   - Push a change that doesn’t produce a coverage report (e.g. skip tests or delete `coverage.xml`).  
   - Observe that the upload steps are skipped, and no “artifact not found” warnings appear in the Actions log.
2. **Coverage present**  
   - Run the full test suite locally to generate `backend/coverage.xml` and `frontend/coverage/lcov-report`.  
   - Push the change; confirm that both coverage upload steps execute, the combined coverage job downloads them successfully, and the report links are printed.
3. **Pull request flow**  
   - Open a PR against `master` for both scenarios above and verify that no errors or warnings surface in either the “Formatting”, “Tests”, “Combined Coverage Reports”, or “Artifacts” sections of the Actions UI.

---

## Pre-merge author checklist

- [x] I've clearly explained:  
  - [x] What problem this PR is solving.  
  - [x] How this problem was solved.  
  - [x] How reviewers can test my changes.  
- [x] I've included tests I've run to ensure my changes work.  
- [x] I've added unit tests for any new code, if applicable.  
- [x] I've documented any added code.  
