### PR TITLE
feat(ui): center hero stats section on mobile for improved layout

### DIFF
--- a/packages/styles.css
+++ b/packages/styles.css
@@ -763,6 +763,7 @@ a:hover {
     
     .hero-stats {
         grid-template-columns: 1fr;
+        justify-items: center;
     }
 }
 


### PR DESCRIPTION
This pull request includes a minor update to the styling of the `.hero-stats` class in `packages/styles.css`. The change centers the items within the grid layout for improved visual alignment.