### PR TITLE
fix(frontend): clear ESLint warnings breaking CI build

### DIFF
--- a/frontend/src/components/Profile/Profile.js
+++ b/frontend/src/components/Profile/Profile.js
@@ -17,7 +17,6 @@ import {
   Paper,
   Stack,
   TextField,
-  Tooltip,
   Typography,
 } from "@mui/material";
 import {
@@ -25,7 +24,6 @@ import {
   AutoAwesome,
   Clear,
   Delete,
-  Edit,
   Email,
   HistoryToggleOff,
   Key,
@@ -55,7 +53,7 @@ import { logTrackOpen } from "../../services/listening";
 import { API_URL, MODAL_API_URL } from "../../config";
 import { logout as clearAuthTokens, setTokens } from "../../services/auth";
 
-const USERNAME_RE = /^[A-Za-z0-9_.\-]{3,30}$/;
+const USERNAME_RE = /^[A-Za-z0-9_.-]{3,30}$/;
 
 // Brand gradient palette shared with the Results page for saved tracks.
 const PROFILE_TRACK_PALETTE = ["#ff4d4d", "#ff7a59", "#ec4899"];
@@ -367,7 +365,10 @@ const ProfilePage = () => {
 
   // ------------ derived ------------
   const moods = userData?.mood_history || [];
-  const recs = userData?.recommendations || [];
+  const recs = useMemo(
+    () => userData?.recommendations || [],
+    [userData?.recommendations],
+  );
 
   // ---- saved-recommendations search + sort ----
   const RECS_SORTS = [

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -5,7 +5,6 @@ import {
   Box,
   Button,
   Card,
-  Chip,
   CircularProgress,
   IconButton,
   InputAdornment,
@@ -15,7 +14,6 @@ import {
   Skeleton,
   Stack,
   TextField,
-  Tooltip,
   Typography,
 } from "@mui/material";
 import {


### PR DESCRIPTION
## Summary
- CRA treats warnings as errors when `CI=true`, so the ESLint findings on `Profile.js` + `ResultsPage.js` were breaking `npm run build` on every PR.
- Removed unused MUI imports (`Tooltip`, `Edit`, `Chip`).
- Fixed `no-useless-escape` in `USERNAME_RE` by moving `-` to the end of the character class.
- Wrapped `recs` in `useMemo` so the `filteredRecs` dep array is stable (resolves the `react-hooks/exhaustive-deps` warning).

## Failing build excerpt
```
src/components/Profile/Profile.js
  Line 20:3:   'Tooltip' is defined but never used
  Line 28:3:   'Edit' is defined but never used
  Line 58:35:  Unnecessary escape character: \-
  Line 370:9:  The 'recs' logical expression could make the dependencies of useMemo Hook (at line 415) change on every render.

src/pages/ResultsPage.js
  Line 8:3:   'Chip' is defined but never used
  Line 18:3:  'Tooltip' is defined but never used
```

## Test plan
- [x] `CI=true npm run build` → `Compiled successfully.`
- [x] `npx eslint src/components/Profile/Profile.js src/pages/ResultsPage.js` → exit 0
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)