### PR TITLE
Optimize mood and listening history handling with useMemo

### DIFF
--- a/frontend/src/components/Profile/Profile.js
+++ b/frontend/src/components/Profile/Profile.js
@@ -368,8 +368,13 @@ const ProfilePage = () => {
   // ``moods`` keeps the raw history so the stat card can show the
   // total number of detections; ``recentMoods`` is the deduped,
   // newest-first list rendered as chips (repeats collapse into a
-  // single chip).
-  const moods = userData?.mood_history || [];
+  // single chip). Both wrapped in useMemo so their identity is stable
+  // -- the `|| []` fallback would otherwise allocate a fresh array on
+  // every render and invalidate every downstream memo.
+  const moods = useMemo(
+    () => userData?.mood_history || [],
+    [userData?.mood_history],
+  );
   const recentMoods = useMemo(() => uniqRecent(moods), [moods]);
   const recs = useMemo(
     () => userData?.recommendations || [],
@@ -430,7 +435,13 @@ const ProfilePage = () => {
   useEffect(() => {
     setRecsVisible(RECS_PAGE);
   }, [recsQuery, recsSort]);
-  const listening = userData?.listening_history || [];
+  // Wrapped in useMemo so the `|| []` fallback's identity stays
+  // stable across renders -- prevents the downstream `recentListening`
+  // memo from invalidating every paint.
+  const listening = useMemo(
+    () => userData?.listening_history || [],
+    [userData?.listening_history],
+  );
   // Deduped, newest-first view of the listening log. Stat card still
   // reads ``listening.length`` for the raw total.
   const recentListening = useMemo(

--- a/frontend/src/pages/HomePage.js
+++ b/frontend/src/pages/HomePage.js
@@ -801,43 +801,6 @@ const HomePage = () => {
     }
   };
 
-  const moodMap = {
-    joy: "hip-hop",
-    happy: "happy",
-    sadness: "sad",
-    anger: "metal",
-    love: "romance",
-    fear: "sad",
-    neutral: "pop",
-    calm: "chill",
-    disgust: "blues",
-    surprised: "party",
-    surprise: "party",
-    excited: "party",
-    bored: "pop",
-    tired: "chill",
-    relaxed: "chill",
-    stressed: "chill",
-    anxious: "chill",
-    depressed: "sad",
-    lonely: "sad",
-    energetic: "hip-hop",
-    nostalgic: "pop",
-    confused: "pop",
-    frustrated: "metal",
-    hopeful: "romance",
-    proud: "hip-hop",
-    guilty: "blues",
-    jealous: "pop",
-    ashamed: "blues",
-    disappointed: "pop",
-    content: "chill",
-    insecure: "pop",
-    embarrassed: "blues",
-    overwhelmed: "chill",
-    amused: "party",
-  };
-
   const handleAudioUpload = async () => {
     if (!audioBlob) {
       console.log("No audio blob available for upload.");


### PR DESCRIPTION
This pull request improves the stability and efficiency of memoization in the `ProfilePage` component by ensuring that fallback arrays do not cause unnecessary re-renders. Additionally, it removes an unused `moodMap` object from the `HomePage` component, cleaning up the codebase.

**Memoization improvements in `ProfilePage`:**
- Wrapped the fallback arrays for `moods` and `listening` in `useMemo` to maintain stable references across renders, preventing unnecessary invalidation of downstream memoized computations. [[1]](diffhunk://#diff-da0568227d5e9359153abb2209c3d509198bae1f1dd2ac8f3e2e5d3794a95344L371-R377) [[2]](diffhunk://#diff-da0568227d5e9359153abb2209c3d509198bae1f1dd2ac8f3e2e5d3794a95344L433-R444)

**Code cleanup in `HomePage`:**
- Removed the unused `moodMap` object from `HomePage.js` to reduce clutter and improve maintainability.