### PR TITLE
test(frontend): snapshot tests for all screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1322,6 +1322,22 @@ npm test:coverage
 
 This will run all the tests in the frontend directory and generate a coverage report. Ensure that all tests pass before deploying the frontend application.
 
+#### **Snapshot Tests**
+
+Every screen in the app is covered by a **snapshot test** under `frontend/src/__tests__/snapshots/` (one file per screen: Landing, Home, Profile, Results, Recommendations, Not Found, Forgot Password, Passkeys, Privacy Policy, and Terms of Service). Each renders the screen inside the providers it needs (dark-mode context, router, toast) and asserts the rendered markup with `toMatchSnapshot()`, so unintended UI changes surface in the diff. The committed baselines live in the adjacent `__snapshots__/` directory.
+
+```bash
+cd frontend
+
+# Run only the snapshot suite
+npm test -- src/__tests__/snapshots
+
+# Update the snapshots after an intentional UI change
+npm test -- -u
+```
+
+After a deliberate UI change, run `npm test -- -u` to refresh the baselines, then commit the updated `.snap` files alongside your change.
+
 <h2 id="-kubernetes">☸️ Kubernetes</h2>
 
 We also added Kubernetes deployment files for the backend and frontend services. You can deploy the services on a Kubernetes cluster using the provided YAML files.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -495,6 +495,29 @@ npm start
 
 This will start the React application at `http://localhost:3000`. If this port is in use, you may be prompted to use a different port.
 
+### Testing
+
+The frontend uses **Jest** with **React Testing Library**. Tests live under `src/**/__tests__/` and include a full set of **snapshot tests** for every screen in `src/__tests__/snapshots/` (one file per screen — Landing, Home, Profile, Results, Recommendations, Not Found, Forgot Password, Passkeys, Privacy Policy, Terms of Service). Each snapshot test renders the page inside its providers and asserts the rendered markup with `toMatchSnapshot()`, so any unintended UI change shows up as a snapshot diff. Baselines are committed under the adjacent `__snapshots__/` directories.
+
+```bash
+# Run the full test suite
+npm test
+
+# Watch mode (re-runs on file changes)
+npm run test:watch
+
+# Coverage report
+npm run test:coverage
+
+# Run only the snapshot suite
+npm test -- src/__tests__/snapshots
+
+# Update snapshots after an intentional UI change
+npm test -- -u
+```
+
+When you change a screen on purpose, update its snapshot with `npm test -- -u` and commit the refreshed `.snap` file with your change.
+
 ### Contributing
 
 Contributions are welcome! Feel free to fork the repository and submit a pull request.

--- a/frontend/src/__tests__/snapshots/ForgotPassword.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/ForgotPassword.snapshot.test.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { DarkModeContext } from "../../context/DarkModeContext";
+
+jest.mock("axios");
+
+jest.mock("react-router-dom", () => {
+  const actual = jest.requireActual("react-router-dom");
+  return { ...actual, useNavigate: () => jest.fn() };
+});
+
+jest.mock("../../components/Toast", () => ({
+  useToast: () => ({
+    show: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  }),
+}));
+
+import ForgotPassword from "../../pages/ForgotPassword";
+
+describe("ForgotPassword snapshot", () => {
+  it("matches the rendered markup", () => {
+    const { asFragment } = render(
+      <DarkModeContext.Provider value={{ isDarkMode: false }}>
+        <MemoryRouter initialEntries={["/forgot-password"]}>
+          <ForgotPassword />
+        </MemoryRouter>
+      </DarkModeContext.Provider>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/snapshots/ForgotPassword.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/ForgotPassword.snapshot.test.jsx
@@ -22,6 +22,16 @@ jest.mock("../../components/Toast", () => ({
 
 import ForgotPassword from "../../pages/ForgotPassword";
 
+// The first field uses autoFocus, which toggles MUI's focus classes. jsdom
+// honors autoFocus inconsistently across environments (it focuses locally but
+// not in CI), so neutralize focus to keep the snapshot stable everywhere.
+beforeAll(() => {
+  jest.spyOn(HTMLElement.prototype, "focus").mockImplementation(() => {});
+});
+afterAll(() => {
+  HTMLElement.prototype.focus.mockRestore();
+});
+
 describe("ForgotPassword snapshot", () => {
   it("matches the rendered markup", () => {
     const { asFragment } = render(

--- a/frontend/src/__tests__/snapshots/HomePage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/HomePage.snapshot.test.jsx
@@ -20,14 +20,20 @@ jest.mock("../../components/Toast", () => ({
 import HomePage from "../../pages/HomePage";
 
 // HomePage greets the user based on the current hour ("Good morning/..."), so
-// freeze "now" to keep the snapshot stable across runs.
+// freeze "now" to keep the snapshot stable across runs. getHours() is
+// host-local, so it's pinned to a fixed value too — otherwise the greeting
+// differs between a local machine and CI's UTC runner.
 const RealDate = Date;
 const FIXED_ISO = "2024-06-15T12:00:00.000Z";
+const FIXED_HOUR = 9; // -> "Good morning", independent of the host timezone
 
 beforeAll(() => {
   global.Date = class extends RealDate {
     constructor(...args) {
       super(...(args.length ? args : [FIXED_ISO]));
+    }
+    getHours() {
+      return FIXED_HOUR;
     }
     static now() {
       return new RealDate(FIXED_ISO).getTime();

--- a/frontend/src/__tests__/snapshots/HomePage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/HomePage.snapshot.test.jsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import axios from "axios";
+import { MemoryRouter } from "react-router-dom";
+import { DarkModeContext } from "../../context/DarkModeContext";
+
+jest.mock("axios");
+
+// HomePage consumes the Toast context; provide a no-op stub.
+jest.mock("../../components/Toast", () => ({
+  useToast: () => ({
+    show: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  }),
+}));
+
+import HomePage from "../../pages/HomePage";
+
+// HomePage greets the user based on the current hour ("Good morning/..."), so
+// freeze "now" to keep the snapshot stable across runs.
+const RealDate = Date;
+const FIXED_ISO = "2024-06-15T12:00:00.000Z";
+
+beforeAll(() => {
+  global.Date = class extends RealDate {
+    constructor(...args) {
+      super(...(args.length ? args : [FIXED_ISO]));
+    }
+    static now() {
+      return new RealDate(FIXED_ISO).getTime();
+    }
+  };
+});
+
+afterAll(() => {
+  global.Date = RealDate;
+});
+
+describe("HomePage snapshot", () => {
+  beforeEach(() => {
+    window.localStorage.setItem("token", "fake-jwt-token");
+    axios.get.mockResolvedValue({
+      data: {
+        id: "user-123",
+        username: "Test User",
+        mood_history: [],
+        recommendations: [],
+        listening_history: [],
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    window.localStorage.clear();
+  });
+
+  it("matches the rendered markup once the profile loads", async () => {
+    const { asFragment } = render(
+      <DarkModeContext.Provider value={{ isDarkMode: false }}>
+        <MemoryRouter>
+          <HomePage />
+        </MemoryRouter>
+      </DarkModeContext.Provider>,
+    );
+
+    // Wait for the greeting to pick up the loaded username so the async state
+    // has settled before we snapshot.
+    await screen.findByText(/Test User/);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/snapshots/HomePage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/HomePage.snapshot.test.jsx
@@ -33,10 +33,14 @@ beforeAll(() => {
       return new RealDate(FIXED_ISO).getTime();
     }
   };
+  // autoFocus toggles MUI focus classes and jsdom applies it inconsistently
+  // across environments; neutralize focus to keep the snapshot stable.
+  jest.spyOn(HTMLElement.prototype, "focus").mockImplementation(() => {});
 });
 
 afterAll(() => {
   global.Date = RealDate;
+  HTMLElement.prototype.focus.mockRestore();
 });
 
 describe("HomePage snapshot", () => {

--- a/frontend/src/__tests__/snapshots/LandingPage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/LandingPage.snapshot.test.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { DarkModeContext } from "../../context/DarkModeContext";
+
+// The procedural 3D background probes WebGL via canvas.getContext, which jsdom
+// can't provide. Stub it so the snapshot is stable and free of WebGL noise.
+jest.mock("../../components/PageBackground", () => () => (
+  <div data-testid="page-background-mock" />
+));
+
+// react-slick renders a carousel that depends on layout measurement; replace
+// it with a no-op so the markup is deterministic.
+jest.mock("react-slick", () => () => <div data-testid="slider-mock" />);
+
+jest.mock("react-router-dom", () => {
+  const actual = jest.requireActual("react-router-dom");
+  return { ...actual, useNavigate: () => jest.fn() };
+});
+
+import LandingPage from "../../pages/LandingPage";
+
+describe("LandingPage snapshot", () => {
+  it("matches the rendered markup", () => {
+    const { asFragment } = render(
+      <DarkModeContext.Provider value={{ isDarkMode: false }}>
+        <MemoryRouter initialEntries={["/"]}>
+          <LandingPage />
+        </MemoryRouter>
+      </DarkModeContext.Provider>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/snapshots/NotFoundPage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/NotFoundPage.snapshot.test.jsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { DarkModeContext } from "../../context/DarkModeContext";
+
+jest.mock("react-router-dom", () => {
+  const actual = jest.requireActual("react-router-dom");
+  return { ...actual, useNavigate: () => jest.fn() };
+});
+
+import NotFoundPage from "../../pages/NotFoundPage";
+
+describe("NotFoundPage snapshot", () => {
+  it("matches the rendered markup", () => {
+    const { asFragment } = render(
+      <DarkModeContext.Provider value={{ isDarkMode: false }}>
+        <MemoryRouter initialEntries={["/does-not-exist"]}>
+          <NotFoundPage />
+        </MemoryRouter>
+      </DarkModeContext.Provider>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/snapshots/PasskeysPage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/PasskeysPage.snapshot.test.jsx
@@ -36,6 +36,15 @@ jest.mock("../../services/passkeys", () => ({
 
 import PasskeysPage from "../../pages/PasskeysPage";
 
+// The rename dialog uses autoFocus; jsdom applies focus inconsistently across
+// environments, so neutralize it to keep the snapshot stable everywhere.
+beforeAll(() => {
+  jest.spyOn(HTMLElement.prototype, "focus").mockImplementation(() => {});
+});
+afterAll(() => {
+  HTMLElement.prototype.focus.mockRestore();
+});
+
 describe("PasskeysPage snapshot", () => {
   it("matches the rendered markup once the passkey list loads", async () => {
     const { asFragment } = render(

--- a/frontend/src/__tests__/snapshots/PasskeysPage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/PasskeysPage.snapshot.test.jsx
@@ -1,0 +1,55 @@
+import React from "react";
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { DarkModeContext } from "../../context/DarkModeContext";
+
+jest.mock("react-router-dom", () => {
+  const actual = jest.requireActual("react-router-dom");
+  return { ...actual, useNavigate: () => jest.fn() };
+});
+
+jest.mock("../../components/Toast", () => ({
+  useToast: () => ({
+    show: jest.fn(),
+    success: jest.fn(),
+    warning: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+  }),
+}));
+
+// The page lists the user's passkeys on mount via the passkeys service. Mock it
+// so there's no real network/WebAuthn dependency and the markup is stable.
+jest.mock("../../services/passkeys", () => ({
+  __esModule: true,
+  listPasskeys: jest.fn().mockResolvedValue([]),
+  isPasskeySupported: jest.fn().mockReturnValue(true),
+  registerPasskey: jest.fn(),
+  renamePasskey: jest.fn(),
+  deletePasskey: jest.fn(),
+  PasskeyError: class PasskeyError extends Error {},
+}));
+
+import PasskeysPage from "../../pages/PasskeysPage";
+
+describe("PasskeysPage snapshot", () => {
+  it("matches the rendered markup once the passkey list loads", async () => {
+    const { asFragment } = render(
+      <DarkModeContext.Provider value={{ isDarkMode: false }}>
+        <MemoryRouter initialEntries={["/passkeys"]}>
+          <PasskeysPage />
+        </MemoryRouter>
+      </DarkModeContext.Provider>,
+    );
+
+    // Loading spinner shows first; wait for it to clear so we snapshot the
+    // settled (empty) list state.
+    await waitForElementToBeRemoved(() => screen.queryByRole("progressbar"));
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/snapshots/PrivacyPolicyPage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/PrivacyPolicyPage.snapshot.test.jsx
@@ -13,6 +13,12 @@ beforeAll(() => {
     constructor(...args) {
       super(...(args.length ? args : [FIXED_ISO]));
     }
+    // Pin the displayed date so it's independent of the host timezone and
+    // locale (the calendar date of FIXED_ISO would otherwise roll over in
+    // far-east timezones, and the format would vary by locale).
+    toLocaleDateString() {
+      return "June 15, 2024";
+    }
     static now() {
       return new RealDate(FIXED_ISO).getTime();
     }

--- a/frontend/src/__tests__/snapshots/PrivacyPolicyPage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/PrivacyPolicyPage.snapshot.test.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { DarkModeContext } from "../../context/DarkModeContext";
+import PrivacyPolicyPage from "../../pages/PrivacyPolicyPage";
+
+// LegalLayout stamps the current date ("Last updated ..."). Freeze "now" so the
+// snapshot doesn't drift day to day, while keeping date parsing intact.
+const RealDate = Date;
+const FIXED_ISO = "2024-06-15T12:00:00.000Z";
+
+beforeAll(() => {
+  global.Date = class extends RealDate {
+    constructor(...args) {
+      super(...(args.length ? args : [FIXED_ISO]));
+    }
+    static now() {
+      return new RealDate(FIXED_ISO).getTime();
+    }
+  };
+});
+
+afterAll(() => {
+  global.Date = RealDate;
+});
+
+describe("PrivacyPolicyPage snapshot", () => {
+  it("matches the rendered markup", () => {
+    const { asFragment } = render(
+      <DarkModeContext.Provider value={{ isDarkMode: false }}>
+        <PrivacyPolicyPage />
+      </DarkModeContext.Provider>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/snapshots/ProfilePage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/ProfilePage.snapshot.test.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import axios from "axios";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { DarkModeContext } from "../../context/DarkModeContext";
+import ProfilePage from "../../pages/ProfilePage";
+
+jest.mock("axios");
+
+jest.mock("react-router-dom", () => {
+  const actual = jest.requireActual("react-router-dom");
+  return { ...actual, useNavigate: () => jest.fn() };
+});
+
+// Profile fetch errors are logged on the unhappy path; keep the happy path quiet.
+beforeAll(() => jest.spyOn(console, "error").mockImplementation(() => {}));
+afterAll(() => console.error.mockRestore());
+
+describe("ProfilePage snapshot", () => {
+  const fakeUser = {
+    username: "testuser",
+    email: "test@example.com",
+    mood_history: ["Happy", "Sad"],
+    recommendations: [
+      {
+        name: "Song X",
+        artist: "Artist X",
+        image_url: "img.jpg",
+        preview_url: "preview.mp3",
+        external_url: "https://spotify.com/x",
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.setItem("token", "token123");
+    window.localStorage.removeItem("userProfileCache");
+  });
+
+  afterEach(() => window.localStorage.clear());
+
+  it("matches the rendered markup once the profile loads", async () => {
+    axios.get.mockResolvedValueOnce({ data: fakeUser });
+
+    const { asFragment } = render(
+      <DarkModeContext.Provider value={{ isDarkMode: false }}>
+        <MemoryRouter initialEntries={["/profile"]}>
+          <Routes>
+            <Route path="/profile" element={<ProfilePage />} />
+          </Routes>
+        </MemoryRouter>
+      </DarkModeContext.Provider>,
+    );
+
+    // Wait for the loaded state so we snapshot the populated profile, not the
+    // transient "Loading..." view.
+    await screen.findByText(/Welcome, testuser!/i);
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/snapshots/RecommendationsPage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/RecommendationsPage.snapshot.test.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import RecommendationsPage from "../../pages/RecommendationsPage";
+
+describe("RecommendationsPage snapshot", () => {
+  it("matches the rendered markup", () => {
+    const { asFragment } = render(<RecommendationsPage />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/snapshots/ResultsPage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/ResultsPage.snapshot.test.jsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { DarkModeContext } from "../../context/DarkModeContext";
+import ResultsPage from "../../pages/ResultsPage";
+
+// jsdom doesn't implement media playback; TrackPlayer calls play/pause.
+beforeAll(() => {
+  Object.defineProperty(window.HTMLMediaElement.prototype, "play", {
+    configurable: true,
+    value: jest.fn().mockResolvedValue(undefined),
+  });
+  Object.defineProperty(window.HTMLMediaElement.prototype, "pause", {
+    configurable: true,
+    value: jest.fn(),
+  });
+  // ResultsPage shuffles recommendations with Math.random; pin it so the
+  // rendered order (and therefore the snapshot) is deterministic.
+  jest.spyOn(global.Math, "random").mockReturnValue(0);
+});
+
+afterAll(() => {
+  global.Math.random.mockRestore();
+});
+
+describe("ResultsPage snapshot", () => {
+  const state = {
+    emotion: "happy",
+    recommendations: [
+      {
+        name: "Song A",
+        artist: "Artist A",
+        image_url: "http://example.com/a.jpg",
+        preview_url: "http://example.com/a.mp3",
+        external_url: "http://spotify.com/a",
+      },
+      {
+        name: "Song B",
+        artist: "Artist B",
+        image_url: "http://example.com/b.jpg",
+        preview_url: null,
+        external_url: "http://spotify.com/b",
+      },
+    ],
+  };
+
+  it("matches the rendered markup", () => {
+    // Signed out (no token) so the page renders the passed-in state without
+    // firing a personalized refetch on mount.
+    const { asFragment } = render(
+      <DarkModeContext.Provider value={{ isDarkMode: false }}>
+        <MemoryRouter initialEntries={[{ pathname: "/results", state }]}>
+          <Routes>
+            <Route path="/results" element={<ResultsPage />} />
+          </Routes>
+        </MemoryRouter>
+      </DarkModeContext.Provider>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/snapshots/TermsOfServicePage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/TermsOfServicePage.snapshot.test.jsx
@@ -13,6 +13,12 @@ beforeAll(() => {
     constructor(...args) {
       super(...(args.length ? args : [FIXED_ISO]));
     }
+    // Pin the displayed date so it's independent of the host timezone and
+    // locale (the calendar date of FIXED_ISO would otherwise roll over in
+    // far-east timezones, and the format would vary by locale).
+    toLocaleDateString() {
+      return "June 15, 2024";
+    }
     static now() {
       return new RealDate(FIXED_ISO).getTime();
     }

--- a/frontend/src/__tests__/snapshots/TermsOfServicePage.snapshot.test.jsx
+++ b/frontend/src/__tests__/snapshots/TermsOfServicePage.snapshot.test.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { DarkModeContext } from "../../context/DarkModeContext";
+import TermsOfServicePage from "../../pages/TermsOfServicePage";
+
+// LegalLayout stamps the current date ("Last updated ..."). Freeze "now" so the
+// snapshot doesn't drift day to day, while keeping date parsing intact.
+const RealDate = Date;
+const FIXED_ISO = "2024-06-15T12:00:00.000Z";
+
+beforeAll(() => {
+  global.Date = class extends RealDate {
+    constructor(...args) {
+      super(...(args.length ? args : [FIXED_ISO]));
+    }
+    static now() {
+      return new RealDate(FIXED_ISO).getTime();
+    }
+  };
+});
+
+afterAll(() => {
+  global.Date = RealDate;
+});
+
+describe("TermsOfServicePage snapshot", () => {
+  it("matches the rendered markup", () => {
+    const { asFragment } = render(
+      <DarkModeContext.Provider value={{ isDarkMode: false }}>
+        <TermsOfServicePage />
+      </DarkModeContext.Provider>,
+    );
+
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/__tests__/snapshots/__snapshots__/ForgotPassword.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/ForgotPassword.snapshot.test.jsx.snap
@@ -1,0 +1,218 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ForgotPassword snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    style="min-height: calc(100vh - 80px); display: flex; justify-content: center; align-items: center; padding: 24px; background-color: rgb(249, 249, 249); transition: background-color 0.3s ease, color 0.3s ease;"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation6 css-1e8lza2-MuiPaper-root"
+      style="--Paper-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);"
+    >
+      <div
+        class="MuiBox-root css-tuo465"
+      >
+        <div
+          class="MuiBox-root css-1dhcmut"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1axninp-MuiSvgIcon-root"
+            data-testid="ShieldOutlinedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 2 4 5v6.09c0 5.05 3.41 9.76 8 10.91 4.59-1.15 8-5.86 8-10.91V5zm6 9.09c0 4-2.55 7.7-6 8.83-3.45-1.13-6-4.82-6-8.83v-4.7l6-2.25 6 2.25z"
+            />
+          </svg>
+        </div>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-6586k7-MuiTypography-root"
+        >
+          Reset your password
+        </p>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-1j4pi34-MuiTypography-root"
+        >
+          Step 1 of 2 - verify
+        </p>
+        <div
+          class="MuiBox-root css-51f4gr"
+        >
+          <span
+            aria-valuemax="100"
+            aria-valuemin="0"
+            aria-valuenow="50"
+            class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-1fotnoe-MuiLinearProgress-root"
+            role="progressbar"
+          >
+            <span
+              class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+              style="transform: translateX(-50%);"
+            />
+          </span>
+          <div
+            class="MuiStack-root css-1eqpy83-MuiStack-root"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-13xgels-MuiTypography-root"
+            >
+              Verify
+            </p>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-13xgels-MuiTypography-root"
+            >
+              Reset
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-184skkq"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-wu87xy-MuiTypography-root"
+        >
+          Confirm your username and email to continue.
+        </p>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-dzmwfx-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for=":r0:"
+            id=":r0:-label"
+            style="font-family: Poppins; color: rgb(102, 102, 102);"
+          >
+            Username
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-adornedStart css-ot336b-MuiInputBase-root-MuiOutlinedInput-root"
+            style="font-family: Poppins; font-size: 15px; color: rgb(0, 0, 0);"
+          >
+            <div
+              class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1nowbqt-MuiInputAdornment-root"
+            >
+              <span
+                aria-hidden="true"
+                class="notranslate"
+              >
+                ​
+              </span>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q91y74-MuiSvgIcon-root"
+                data-testid="PersonOutlineIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 5.9c1.16 0 2.1.94 2.1 2.1s-.94 2.1-2.1 2.1S9.9 9.16 9.9 8s.94-2.1 2.1-2.1m0 9c2.97 0 6.1 1.46 6.1 2.1v1.1H5.9V17c0-.64 3.13-2.1 6.1-2.1M12 4C9.79 4 8 5.79 8 8s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4m0 9c-2.67 0-8 1.34-8 4v3h16v-3c0-2.66-5.33-4-8-4"
+                />
+              </svg>
+            </div>
+            <input
+              aria-invalid="false"
+              autocomplete="username"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
+              id=":r0:"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-ex8a5f-MuiNotchedOutlined-root"
+              >
+                <span>
+                  Username
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1dw3j40-MuiFormControl-root-MuiTextField-root"
+        >
+          <label
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+            data-shrink="true"
+            for=":r1:"
+            id=":r1:-label"
+            style="font-family: Poppins; color: rgb(102, 102, 102);"
+          >
+            Email
+          </label>
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart css-ot336b-MuiInputBase-root-MuiOutlinedInput-root"
+            style="font-family: Poppins; font-size: 15px; color: rgb(0, 0, 0);"
+          >
+            <div
+              class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeMedium css-1nowbqt-MuiInputAdornment-root"
+            >
+              <span
+                aria-hidden="true"
+                class="notranslate"
+              >
+                ​
+              </span>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1q91y74-MuiSvgIcon-root"
+                data-testid="AlternateEmailIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10h5v-2h-5c-4.34 0-8-3.66-8-8s3.66-8 8-8 8 3.66 8 8v1.43c0 .79-.71 1.57-1.5 1.57s-1.5-.78-1.5-1.57V12c0-2.76-2.24-5-5-5s-5 2.24-5 5 2.24 5 5 5c1.38 0 2.64-.56 3.54-1.47.65.89 1.77 1.47 2.96 1.47 1.97 0 3.5-1.6 3.5-3.57V12c0-5.52-4.48-10-10-10m0 13c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3"
+                />
+              </svg>
+            </div>
+            <input
+              aria-invalid="false"
+              autocomplete="email"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputAdornedStart css-2u11ia-MuiInputBase-input-MuiOutlinedInput-input"
+              id=":r1:"
+              type="email"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-ex8a5f-MuiNotchedOutlined-root"
+              >
+                <span>
+                  Email
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-tlkxp-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          Verify
+        </button>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-19dnzyg-MuiTypography-root"
+        >
+          Back to 
+          <span
+            class="MuiBox-root css-1deda8d"
+          >
+            Sign in
+          </span>
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/__tests__/snapshots/__snapshots__/ForgotPassword.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/ForgotPassword.snapshot.test.jsx.snap
@@ -80,7 +80,7 @@ exports[`ForgotPassword snapshot matches the rendered markup 1`] = `
           class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-dzmwfx-MuiFormControl-root-MuiTextField-root"
         >
           <label
-            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary Mui-focused MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
+            class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeMedium MuiInputLabel-outlined css-113d811-MuiFormLabel-root-MuiInputLabel-root"
             data-shrink="true"
             for=":r0:"
             id=":r0:-label"
@@ -89,7 +89,7 @@ exports[`ForgotPassword snapshot matches the rendered markup 1`] = `
             Username
           </label>
           <div
-            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth Mui-focused MuiInputBase-formControl MuiInputBase-adornedStart css-ot336b-MuiInputBase-root-MuiOutlinedInput-root"
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart css-ot336b-MuiInputBase-root-MuiOutlinedInput-root"
             style="font-family: Poppins; font-size: 15px; color: rgb(0, 0, 0);"
           >
             <div

--- a/frontend/src/__tests__/snapshots/__snapshots__/HomePage.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/HomePage.snapshot.test.jsx.snap
@@ -1,0 +1,734 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HomePage snapshot matches the rendered markup once the profile loads 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-pcyejk"
+  >
+    <div
+      class="MuiBox-root css-1uk4dgm"
+    >
+      <div
+        class="MuiStack-root css-pdbrj-MuiStack-root"
+      >
+        <div
+          class="MuiBox-root css-0"
+        >
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-db8vxp-MuiTypography-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1ayao2y-MuiSvgIcon-root"
+              data-testid="LightbulbIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M9 21c0 .5.4 1 1 1h4c.6 0 1-.5 1-1v-1H9zm3-19C8.1 2 5 5.1 5 9c0 2.4 1.2 4.5 3 5.7V17c0 .5.4 1 1 1h6c.6 0 1-.5 1-1v-2.3c1.8-1.3 3-3.4 3-5.7 0-3.9-3.1-7-7-7"
+              />
+            </svg>
+            Good morning, Test User
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-k2ul5p-MuiTypography-root"
+          >
+            How are you feeling 
+            <span
+              class="MuiBox-root css-1hth1dv"
+            >
+              today?
+            </span>
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1d0qdz1-MuiTypography-root"
+          >
+            Share your vibe through text, voice or a selfie - we'll tune the music to it.
+          </p>
+        </div>
+        <div
+          class="MuiStack-root css-1vthj35-MuiStack-root"
+        >
+          <div
+            class="MuiStack-root css-tpfhp9-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-x0r8r3"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-19pfla-MuiSvgIcon-root"
+                data-testid="MoodOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8m3.5-9c.83 0 1.5-.67 1.5-1.5S16.33 8 15.5 8 14 8.67 14 9.5s.67 1.5 1.5 1.5m-7 0c.83 0 1.5-.67 1.5-1.5S9.33 8 8.5 8 7 8.67 7 9.5 7.67 11 8.5 11m3.5 6.5c2.33 0 4.31-1.46 5.11-3.5H6.89c.8 2.04 2.78 3.5 5.11 3.5"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiBox-root css-165casq"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-1fcddxu-MuiTypography-root"
+              >
+                0
+              </p>
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-71mds4-MuiTypography-root"
+              >
+                Moods
+              </p>
+            </div>
+          </div>
+          <div
+            class="MuiStack-root css-tpfhp9-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-1bolnxz"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-19pfla-MuiSvgIcon-root"
+                data-testid="LibraryMusicIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M20 2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m-2 5h-3v5.5c0 1.38-1.12 2.5-2.5 2.5S10 13.88 10 12.5s1.12-2.5 2.5-2.5c.57 0 1.08.19 1.5.51V5h4zM4 6H2v14c0 1.1.9 2 2 2h14v-2H4z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiBox-root css-165casq"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-1fcddxu-MuiTypography-root"
+              >
+                0
+              </p>
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-71mds4-MuiTypography-root"
+              >
+                Saved
+              </p>
+            </div>
+          </div>
+          <div
+            class="MuiStack-root css-tpfhp9-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-1p23duz"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-19pfla-MuiSvgIcon-root"
+                data-testid="HistoryIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M13 3c-4.97 0-9 4.03-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.94-2.06l-1.42 1.42C8.27 19.99 10.51 21 13 21c4.97 0 9-4.03 9-9s-4.03-9-9-9m-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiBox-root css-165casq"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-1fcddxu-MuiTypography-root"
+              >
+                0
+              </p>
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-71mds4-MuiTypography-root"
+              >
+                Listened
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1cj4lal-MuiPaper-root"
+        style="--Paper-shadow: none;"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-l0cw3r-MuiTypography-root"
+        >
+          CHOOSE HOW TO SHARE
+        </p>
+        <div
+          class="MuiStack-root css-17jv6mu-MuiStack-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1p1rg52-MuiPaper-root"
+            style="--Paper-shadow: none;"
+          >
+            <div
+              class="MuiBox-root css-p1d63w"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1elotag-MuiSvgIcon-root"
+                data-testid="TextFieldsIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M2.5 4v3h5v12h3V7h5V4zm19 5h-9v3h3v7h3v-7h3z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiBox-root css-1fjtzvx"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-s8hmv3-MuiTypography-root"
+              >
+                Text
+              </p>
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-ep02ea-MuiTypography-root"
+              >
+                Write a few words about your day.
+              </p>
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-iwxxlz-MuiSvgIcon-root"
+              data-testid="KeyboardArrowRightIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-106aazx-MuiPaper-root"
+            style="--Paper-shadow: none;"
+          >
+            <div
+              class="MuiBox-root css-1v0a7x9"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1elotag-MuiSvgIcon-root"
+                data-testid="MicNoneIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 14c1.66 0 2.99-1.34 2.99-3L15 5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3m-1.2-9.1c0-.66.54-1.2 1.2-1.2s1.2.54 1.2 1.2l-.01 6.2c0 .66-.53 1.2-1.19 1.2s-1.2-.54-1.2-1.2zm6.5 6.1c0 3-2.54 5.1-5.3 5.1S6.7 14 6.7 11H5c0 3.41 2.72 6.23 6 6.72V21h2v-3.28c3.28-.48 6-3.3 6-6.72z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiBox-root css-1fjtzvx"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-s8hmv3-MuiTypography-root"
+              >
+                Voice
+              </p>
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-ep02ea-MuiTypography-root"
+              >
+                Record a short voice clip.
+              </p>
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vklni1-MuiSvgIcon-root"
+              data-testid="KeyboardArrowRightIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1x6zgxq-MuiPaper-root"
+            style="--Paper-shadow: none;"
+          >
+            <div
+              class="MuiBox-root css-1wcd7k9"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1elotag-MuiSvgIcon-root"
+                data-testid="FaceRetouchingNaturalIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <circle
+                  cx="9"
+                  cy="13"
+                  r="1.25"
+                />
+                <path
+                  d="m20.77 8.58-.92 2.01c.09.46.15.93.15 1.41 0 4.41-3.59 8-8 8s-8-3.59-8-8c0-.05.01-.1 0-.14 2.6-.98 4.69-2.99 5.74-5.55C11.58 8.56 14.37 10 17.5 10c.45 0 .89-.04 1.33-.1l-.6-1.32-.88-1.93-1.93-.88-2.79-1.27 2.79-1.27.71-.32C14.87 2.33 13.47 2 12 2 6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10c0-1.47-.33-2.87-.9-4.13z"
+                />
+                <circle
+                  cx="15"
+                  cy="13"
+                  r="1.25"
+                />
+                <path
+                  d="M20.6 5.6 19.5 8l-1.1-2.4L16 4.5l2.4-1.1L19.5 1l1.1 2.4L23 4.5z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiBox-root css-1fjtzvx"
+            >
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-s8hmv3-MuiTypography-root"
+              >
+                Face
+              </p>
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-ep02ea-MuiTypography-root"
+              >
+                Snap a photo of your expression.
+              </p>
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-vklni1-MuiSvgIcon-root"
+              data-testid="KeyboardArrowRightIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M8.59 16.59 13.17 12 8.59 7.41 10 6l6 6-6 6z"
+              />
+            </svg>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-wu869l"
+        >
+          <div
+            class="MuiBox-root css-izuqqr"
+          >
+            <div
+              class="MuiBox-root css-yynv2a"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1axninp-MuiSvgIcon-root"
+                data-testid="TextFieldsIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M2.5 4v3h5v12h3V7h5V4zm19 5h-9v3h3v7h3v-7h3z"
+                />
+              </svg>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-q804p5-MuiTypography-root"
+            >
+              Spill it - we'll find the soundtrack
+            </p>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-cu6oc-MuiTypography-root"
+            >
+              Write a few words about your day.
+            </p>
+            <div
+              class="MuiStack-root css-1fu53ur-MuiStack-root"
+            >
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-1r9mwce-MuiButtonBase-root-MuiButton-root"
+                tabindex="0"
+                type="button"
+              >
+                Add Text
+                <span
+                  class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeMedium css-1gulhci-MuiButton-endIcon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                    data-testid="ArrowForwardIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m12 4-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-49165n-MuiButtonBase-root-MuiButton-root"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                    data-testid="CloudUploadIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19.35 10.04C18.67 6.59 15.64 4 12 4 9.11 4 6.6 5.64 5.35 8.04 2.34 8.36 0 10.91 0 14c0 3.31 2.69 6 6 6h13c2.76 0 5-2.24 5-5 0-2.64-2.05-4.78-4.65-4.96M14 13v4h-4v-4H7l5-5 5 5z"
+                    />
+                  </svg>
+                </span>
+                Upload Text File
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-1yjvs5a"
+      >
+        <div
+          class="MuiStack-root css-dghotf-MuiStack-root"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-zqnj85-MuiSvgIcon-root"
+            data-testid="WhatshotIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M13.5.67s.74 2.65.74 4.8c0 2.06-1.35 3.73-3.41 3.73-2.07 0-3.63-1.67-3.63-3.73l.03-.36C5.21 7.51 4 10.62 4 14c0 4.42 3.58 8 8 8s8-3.58 8-8C20 8.61 17.41 3.8 13.5.67M11.71 19c-1.78 0-3.22-1.4-3.22-3.14 0-1.62 1.05-2.76 2.81-3.12 1.77-.36 3.6-1.21 4.62-2.58.39 1.29.59 2.65.59 4.04 0 2.65-2.15 4.8-4.8 4.8"
+            />
+          </svg>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1m66zua-MuiTypography-root"
+          >
+            QUICK PICK A MOOD
+          </p>
+        </div>
+        <div
+          class="MuiStack-root css-pex525-MuiStack-root"
+        >
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault css-jz9ye-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+            >
+              <div
+                class="MuiStack-root css-1aunye9-MuiStack-root"
+              >
+                <span
+                  aria-hidden="true"
+                  style="font-size: 14px;"
+                >
+                  😊
+                </span>
+                <span
+                  class="MuiBox-root css-0"
+                >
+                  Happy
+                </span>
+              </div>
+            </span>
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault css-7knvvj-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+            >
+              <div
+                class="MuiStack-root css-1aunye9-MuiStack-root"
+              >
+                <span
+                  aria-hidden="true"
+                  style="font-size: 14px;"
+                >
+                  😌
+                </span>
+                <span
+                  class="MuiBox-root css-0"
+                >
+                  Calm
+                </span>
+              </div>
+            </span>
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault css-h9dqhs-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+            >
+              <div
+                class="MuiStack-root css-1aunye9-MuiStack-root"
+              >
+                <span
+                  aria-hidden="true"
+                  style="font-size: 14px;"
+                >
+                  😢
+                </span>
+                <span
+                  class="MuiBox-root css-0"
+                >
+                  Sad
+                </span>
+              </div>
+            </span>
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault css-1iq6m0c-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+            >
+              <div
+                class="MuiStack-root css-1aunye9-MuiStack-root"
+              >
+                <span
+                  aria-hidden="true"
+                  style="font-size: 14px;"
+                >
+                  🤩
+                </span>
+                <span
+                  class="MuiBox-root css-0"
+                >
+                  Excited
+                </span>
+              </div>
+            </span>
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault css-krae2d-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+            >
+              <div
+                class="MuiStack-root css-1aunye9-MuiStack-root"
+              >
+                <span
+                  aria-hidden="true"
+                  style="font-size: 14px;"
+                >
+                  🥰
+                </span>
+                <span
+                  class="MuiBox-root css-0"
+                >
+                  In love
+                </span>
+              </div>
+            </span>
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault css-ljvwiq-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+            >
+              <div
+                class="MuiStack-root css-1aunye9-MuiStack-root"
+              >
+                <span
+                  aria-hidden="true"
+                  style="font-size: 14px;"
+                >
+                  😠
+                </span>
+                <span
+                  class="MuiBox-root css-0"
+                >
+                  Angry
+                </span>
+              </div>
+            </span>
+          </div>
+          <div
+            class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault css-14t3u0i-MuiButtonBase-root-MuiChip-root"
+            role="button"
+            tabindex="0"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+            >
+              <div
+                class="MuiStack-root css-1aunye9-MuiStack-root"
+              >
+                <span
+                  aria-hidden="true"
+                  style="font-size: 14px;"
+                >
+                  😐
+                </span>
+                <span
+                  class="MuiBox-root css-0"
+                >
+                  Neutral
+                </span>
+              </div>
+            </span>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiBox-root css-0"
+      >
+        <div
+          class="MuiStack-root css-dghotf-MuiStack-root"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1v0aoqf-MuiSvgIcon-root"
+            data-testid="InsightsIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M21 8c-1.45 0-2.26 1.44-1.93 2.51l-3.55 3.56c-.3-.09-.74-.09-1.04 0l-2.55-2.55C12.27 10.45 11.46 9 10 9c-1.45 0-2.27 1.44-1.93 2.52l-4.56 4.55C2.44 15.74 1 16.55 1 18c0 1.1.9 2 2 2 1.45 0 2.26-1.44 1.93-2.51l4.55-4.56c.3.09.74.09 1.04 0l2.55 2.55C12.73 16.55 13.54 18 15 18c1.45 0 2.27-1.44 1.93-2.52l3.56-3.55c1.07.33 2.51-.48 2.51-1.93 0-1.1-.9-2-2-2"
+            />
+            <path
+              d="m15 9 .94-2.07L18 6l-2.06-.93L15 3l-.92 2.07L12 6l2.08.93zM3.5 11 4 9l2-.5L4 8l-.5-2L3 8l-2 .5L3 9z"
+            />
+          </svg>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1m66zua-MuiTypography-root"
+          >
+            HOW IT WORKS
+          </p>
+        </div>
+        <div
+          class="MuiStack-root css-7kzigw-MuiStack-root"
+        >
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1hizg7m-MuiPaper-root"
+            style="--Paper-shadow: none;"
+          >
+            <div
+              class="MuiBox-root css-yucw08"
+            >
+              1
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-satm0m-MuiSvgIcon-root"
+              data-testid="InsightsIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M21 8c-1.45 0-2.26 1.44-1.93 2.51l-3.55 3.56c-.3-.09-.74-.09-1.04 0l-2.55-2.55C12.27 10.45 11.46 9 10 9c-1.45 0-2.27 1.44-1.93 2.52l-4.56 4.55C2.44 15.74 1 16.55 1 18c0 1.1.9 2 2 2 1.45 0 2.26-1.44 1.93-2.51l4.55-4.56c.3.09.74.09 1.04 0l2.55 2.55C12.73 16.55 13.54 18 15 18c1.45 0 2.27-1.44 1.93-2.52l3.56-3.55c1.07.33 2.51-.48 2.51-1.93 0-1.1-.9-2-2-2"
+              />
+              <path
+                d="m15 9 .94-2.07L18 6l-2.06-.93L15 3l-.92 2.07L12 6l2.08.93zM3.5 11 4 9l2-.5L4 8l-.5-2L3 8l-2 .5L3 9z"
+              />
+            </svg>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-12846yn-MuiTypography-root"
+            >
+              Share a moment
+            </p>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-3autsi-MuiTypography-root"
+            >
+              Pick a mode - type, talk, or smile - and we'll read your vibe.
+            </p>
+          </div>
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1hizg7m-MuiPaper-root"
+            style="--Paper-shadow: none;"
+          >
+            <div
+              class="MuiBox-root css-yucw08"
+            >
+              2
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-satm0m-MuiSvgIcon-root"
+              data-testid="AutoAwesomeIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m19 9 1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25z"
+              />
+            </svg>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-12846yn-MuiTypography-root"
+            >
+              Detect the mood
+            </p>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-3autsi-MuiTypography-root"
+            >
+              Three self-trained models converge on a single emotion label.
+            </p>
+          </div>
+          <div
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1hizg7m-MuiPaper-root"
+            style="--Paper-shadow: none;"
+          >
+            <div
+              class="MuiBox-root css-yucw08"
+            >
+              3
+            </div>
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-satm0m-MuiSvgIcon-root"
+              data-testid="LibraryMusicIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M20 2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m-2 5h-3v5.5c0 1.38-1.12 2.5-2.5 2.5S10 13.88 10 12.5s1.12-2.5 2.5-2.5c.57 0 1.08.19 1.5.51V5h4zM4 6H2v14c0 1.1.9 2 2 2h14v-2H4z"
+              />
+            </svg>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-12846yn-MuiTypography-root"
+            >
+              Tune the music
+            </p>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-3autsi-MuiTypography-root"
+            >
+              We pull a market-aware Deezer playlist that matches the read.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <span
+      class="MuiBox-root css-1hyfx7x"
+    >
+      Text - .txt, .md, .csv, .log, .rtf (max 10 MB)
+    </span>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/__tests__/snapshots/__snapshots__/LandingPage.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/LandingPage.snapshot.test.jsx.snap
@@ -1,0 +1,4767 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LandingPage snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-won9h7"
+  >
+    <div
+      data-testid="page-background-mock"
+    />
+    <div
+      aria-hidden="true"
+      class="MuiBox-root css-1d1svn0"
+    >
+      <div
+        class="MuiBox-root css-1wtzwd3"
+      />
+    </div>
+    <div
+      class="MuiBox-root css-wncndt"
+    >
+      <div
+        aria-hidden="true"
+        class="MuiBox-root css-vyxeys"
+      />
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-hpgcr-MuiContainer-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 MuiGrid-spacing-md-8 css-12roql7-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-1fyyp8j-MuiGrid-root"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-overline reveal reveal-delay-1 css-1h6px3-MuiTypography-root is-visible"
+              data-reveal="true"
+            >
+              Emotion-aware soundtracks
+            </span>
+            <h3
+              class="MuiTypography-root MuiTypography-h3 reveal reveal-delay-1 css-k519cc-MuiTypography-root is-visible"
+              data-reveal="true"
+            >
+              Welcome to 
+              <span
+                class="MuiBox-root css-gvm951"
+              >
+                Moodify
+              </span>
+            </h3>
+            <h6
+              class="MuiTypography-root MuiTypography-h6 reveal reveal-delay-2 css-s4kp25-MuiTypography-root is-visible"
+              data-reveal="true"
+            >
+              The AI-powered emotion-based music recommendation app that matches your mood with the perfect soundtrack.
+            </h6>
+            <p
+              class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-b95yrg-MuiTypography-root is-visible"
+              data-reveal="true"
+            >
+              From calm mornings to high-energy workouts, Moodify interprets how you feel and shapes a soundtrack that adapts in real time. Build emotional routines, save mood journeys, and keep your sound perfectly aligned with your day.
+            </p>
+            <div
+              class="MuiStack-root reveal reveal-delay-3 css-1tanzzc-MuiStack-root is-visible"
+              data-reveal="true"
+            >
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-buxtrm-MuiButtonBase-root-MuiButton-root"
+                tabindex="0"
+                type="button"
+              >
+                Get Started
+              </button>
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-8na1mj-MuiButtonBase-root-MuiButton-root"
+                tabindex="0"
+                type="button"
+              >
+                Log In
+              </button>
+            </div>
+            <div
+              class="MuiStack-root reveal reveal-delay-3 css-1fnvg2j-MuiStack-root is-visible"
+              data-reveal="true"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-a3a136-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                >
+                  Privacy-first personalization
+                </span>
+              </div>
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-a3a136-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                >
+                  Universal design focus
+                </span>
+              </div>
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-a3a136-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                >
+                  Multi-input emotion AI
+                </span>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1akpnp7-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-wg4xta-MuiGrid-root"
+              >
+                <div
+                  class="reveal reveal-delay-1 MuiBox-root css-11uya56 is-visible"
+                  data-reveal="true"
+                >
+                  <div
+                    class="MuiBox-root css-k400sw"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="MicIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 14c1.66 0 2.99-1.34 2.99-3L15 5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3m5.3-3c0 3-2.54 5.1-5.3 5.1S6.7 14 6.7 11H5c0 3.41 2.72 6.23 6 6.72V21h2v-3.28c3.28-.48 6-3.3 6-6.72z"
+                      />
+                    </svg>
+                  </div>
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                  >
+                    3 Input Modes
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Text, voice, or camera
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-wg4xta-MuiGrid-root"
+              >
+                <div
+                  class="reveal reveal-delay-2 MuiBox-root css-11uya56 is-visible"
+                  data-reveal="true"
+                >
+                  <div
+                    class="MuiBox-root css-k400sw"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="BoltIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.38-.66s.05-.08.07-.12C8.48 10.94 10.42 7.54 13 3h1l-1 7h3.5c.49 0 .56.33.47.51l-.07.15C12.96 17.55 11 21 11 21"
+                      />
+                    </svg>
+                  </div>
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                  >
+                    Adaptive Engine
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Updates in real time & on the fly
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-wg4xta-MuiGrid-root"
+              >
+                <div
+                  class="reveal reveal-delay-3 MuiBox-root css-11uya56 is-visible"
+                  data-reveal="true"
+                >
+                  <div
+                    class="MuiBox-root css-k400sw"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="DevicesIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M4 6h18V4H4c-1.1 0-2 .9-2 2v11H0v3h14v-3H4zm19 2h-6c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h6c.55 0 1-.45 1-1V9c0-.55-.45-1-1-1m-1 9h-4v-7h4z"
+                      />
+                    </svg>
+                  </div>
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                  >
+                    Cross-Platform
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Web, mobile, desktop
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-1fyyp8j-MuiGrid-root"
+          >
+            <div
+              class="reveal reveal-delay-2 MuiBox-root css-wcatmg is-visible"
+              data-reveal="true"
+            >
+              <div
+                class="MuiStack-root css-182lidl-MuiStack-root"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Live Mood Snapshot
+                </h6>
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1dvmi47-MuiChip-root"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    Adaptive
+                  </span>
+                </div>
+              </div>
+              <div
+                class="MuiStack-root css-ji5mwz-MuiStack-root"
+              >
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <div
+                    class="MuiStack-root css-1tbtcet-MuiStack-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                    >
+                      Calm
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      72%
+                    </span>
+                  </div>
+                  <span
+                    aria-valuemax="100"
+                    aria-valuemin="0"
+                    aria-valuenow="72"
+                    class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-b1cuxi-MuiLinearProgress-root"
+                    role="progressbar"
+                  >
+                    <span
+                      class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                      style="transform: translateX(-28%);"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <div
+                    class="MuiStack-root css-1tbtcet-MuiStack-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                    >
+                      Focus
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      64%
+                    </span>
+                  </div>
+                  <span
+                    aria-valuemax="100"
+                    aria-valuemin="0"
+                    aria-valuenow="64"
+                    class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-b1cuxi-MuiLinearProgress-root"
+                    role="progressbar"
+                  >
+                    <span
+                      class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                      style="transform: translateX(-36%);"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <div
+                    class="MuiStack-root css-1tbtcet-MuiStack-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                    >
+                      Energy
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      58%
+                    </span>
+                  </div>
+                  <span
+                    aria-valuemax="100"
+                    aria-valuemin="0"
+                    aria-valuenow="58"
+                    class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-b1cuxi-MuiLinearProgress-root"
+                    role="progressbar"
+                  >
+                    <span
+                      class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                      style="transform: translateX(-42%);"
+                    />
+                  </span>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <div
+                    class="MuiStack-root css-1tbtcet-MuiStack-root"
+                  >
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                    >
+                      Confidence
+                    </span>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      81%
+                    </span>
+                  </div>
+                  <span
+                    aria-valuemax="100"
+                    aria-valuemin="0"
+                    aria-valuenow="81"
+                    class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-b1cuxi-MuiLinearProgress-root"
+                    role="progressbar"
+                  >
+                    <span
+                      class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                      style="transform: translateX(-19%);"
+                    />
+                  </span>
+                </div>
+              </div>
+              <hr
+                class="MuiDivider-root MuiDivider-fullWidth css-dmm409-MuiDivider-root"
+              />
+              <div
+                class="MuiStack-root css-10kbc59-MuiStack-root"
+              >
+                <div
+                  class="MuiBox-root css-120nera"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1pu3fmj-MuiAvatar-root"
+                  >
+                    SS
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                    >
+                      Soft Sunrise
+                    </h6>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      Gentle · Warm · 3:24
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root css-120nera"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1pu3fmj-MuiAvatar-root"
+                  >
+                    CF
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                    >
+                      Clear Focus
+                    </h6>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      Intentional · Crisp · 2:58
+                    </span>
+                  </div>
+                </div>
+                <div
+                  class="MuiBox-root css-120nera"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-1pu3fmj-MuiAvatar-root"
+                  >
+                    GS
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                    >
+                      Glow State
+                    </h6>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      Uplifting · Bright · 4:02
+                    </span>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiBox-root css-1raz6df"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                >
+                  Updated just now
+                </span>
+                <div
+                  class="MuiChip-root MuiChip-filled MuiChip-sizeSmall MuiChip-colorDefault MuiChip-filledDefault css-1dvmi47-MuiChip-root"
+                >
+                  <span
+                    class="MuiChip-label MuiChip-labelSmall css-eccknh-MuiChip-label"
+                  >
+                    MoodSync
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-yo84df"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-2zizl3-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4 reveal reveal-delay-1 css-1lj5egr-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <h4
+              class="MuiTypography-root MuiTypography-h4 css-okodwh-MuiTypography-root"
+            >
+              Designed for focus, calm, and momentum
+            </h4>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1a6ve4e-MuiTypography-root"
+            >
+              Moodify is a universal design-first music companion. Every interaction is built to be clear, inclusive, and adaptable, whether you are on mobile, desktop, or listening hands-free.
+            </p>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-8na1mj-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              Explore the platform
+            </button>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8 css-9drkqd-MuiGrid-root"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 reveal reveal-delay-1 css-1b3l6lk-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-10md338"
+                >
+                  <h4
+                    class="MuiTypography-root MuiTypography-h4 css-gxaar7-MuiTypography-root"
+                  >
+                    100+
+                  </h4>
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                  >
+                    Mood tags
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Capture nuance beyond basic emotions.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 reveal reveal-delay-2 css-1b3l6lk-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-10md338"
+                >
+                  <h4
+                    class="MuiTypography-root MuiTypography-h4 css-gxaar7-MuiTypography-root"
+                  >
+                    3
+                  </h4>
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                  >
+                    Input modes
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Type, speak, or use facial cues.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 reveal reveal-delay-3 css-1b3l6lk-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-10md338"
+                >
+                  <h4
+                    class="MuiTypography-root MuiTypography-h4 css-gxaar7-MuiTypography-root"
+                  >
+                    Real-time
+                  </h4>
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                  >
+                    Adaptive playlists
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Soundtracks shift with your energy.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 reveal reveal-delay-1 css-1b3l6lk-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-10md338"
+                >
+                  <h4
+                    class="MuiTypography-root MuiTypography-h4 css-gxaar7-MuiTypography-root"
+                  >
+                    Anywhere
+                  </h4>
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                  >
+                    Device continuity
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Pick up where you left off.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-lde0m7"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <span
+          class="MuiTypography-root MuiTypography-overline reveal reveal-delay-1 css-55u4ba-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Trusted by creative teams and wellness leaders
+        </span>
+      </div>
+      <div
+        class="reveal reveal-delay-2 MuiBox-root css-12zyv6g is-visible"
+        data-reveal="true"
+      >
+        <div
+          class="MuiBox-root css-1wdmst"
+        >
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            Aurora Health
+          </div>
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            Northwind Labs
+          </div>
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            Beacon Studio
+          </div>
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            PulseWorks
+          </div>
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            Lumen Collective
+          </div>
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            Horizon Campus
+          </div>
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            Aurora Health
+          </div>
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            Northwind Labs
+          </div>
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            Beacon Studio
+          </div>
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            PulseWorks
+          </div>
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            Lumen Collective
+          </div>
+          <div
+            class="MuiBox-root css-jkw1bk"
+          >
+            Horizon Campus
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-71tj1p"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="reveal reveal-delay-1 MuiBox-root css-1pvqgwb is-visible"
+          data-reveal="true"
+        >
+          <span
+            class="MuiBox-root css-imdgq3"
+          >
+            By the numbers
+          </span>
+        </div>
+        <h4
+          class="MuiTypography-root MuiTypography-h4 reveal reveal-delay-1 css-1huxlzc-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Moodify at a glance
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-1lk3woo-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Real-time personalization backed by robust infrastructure and an always-learning emotional graph.
+        </p>
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-1 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h3
+                  class="MuiTypography-root MuiTypography-h3 css-1atuopq-MuiTypography-root"
+                >
+                  <span>
+                    48M+
+                  </span>
+                </h3>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Emotion signals processed
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Continuous personalization across active listeners.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-2 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h3
+                  class="MuiTypography-root MuiTypography-h3 css-1atuopq-MuiTypography-root"
+                >
+                  <span>
+                    1.2B+
+                  </span>
+                </h3>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Track embeddings analyzed
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Deep learning context to match every feeling.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-3 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h3
+                  class="MuiTypography-root MuiTypography-h3 css-1atuopq-MuiTypography-root"
+                >
+                  <span>
+                    99.98%
+                  </span>
+                </h3>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  MoodSync uptime
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Reliable access to your playlists all day.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-1 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h3
+                  class="MuiTypography-root MuiTypography-h3 css-1atuopq-MuiTypography-root"
+                >
+                  <span>
+                    120k
+                  </span>
+                </h3>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Daily listening sessions
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Mood-led soundtracks started every day.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-2 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h3
+                  class="MuiTypography-root MuiTypography-h3 css-1atuopq-MuiTypography-root"
+                >
+                  <span>
+                    65+
+                  </span>
+                </h3>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Supported languages
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Global-ready insights and onboarding.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-3 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h3
+                  class="MuiTypography-root MuiTypography-h3 css-1atuopq-MuiTypography-root"
+                >
+                  <span>
+                    14k+
+                  </span>
+                </h3>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Community mood journeys
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Shared playlists curated by listeners.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-71tj1p"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-5 css-1f7ota-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 reveal reveal-delay-1 css-1fyyp8j-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <h4
+              class="MuiTypography-root MuiTypography-h4 css-okodwh-MuiTypography-root"
+            >
+              The emotion intelligence layer
+            </h4>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1a6ve4e-MuiTypography-root"
+            >
+              Moodify blends contextual signals, mood check-ins, and listening intent to deliver a soundscape that evolves with you. The engine stays lightweight and private, while still delivering highly personalized results.
+            </p>
+            <div
+              class="MuiStack-root css-1sazv7p-MuiStack-root"
+            >
+              <div
+                class="reveal reveal-delay-1 MuiBox-root css-11coye2 is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="PsychologyIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M13 8.57c-.79 0-1.43.64-1.43 1.43s.64 1.43 1.43 1.43 1.43-.64 1.43-1.43-.64-1.43-1.43-1.43"
+                    />
+                    <path
+                      d="M13 3C9.25 3 6.2 5.94 6.02 9.64L4.1 12.2c-.25.33-.01.8.4.8H6v3c0 1.1.9 2 2 2h1v3h7v-4.68c2.36-1.12 4-3.53 4-6.32 0-3.87-3.13-7-7-7m3 7c0 .13-.01.26-.02.39l.83.66c.08.06.1.16.05.25l-.8 1.39c-.05.09-.16.12-.24.09l-.99-.4c-.21.16-.43.29-.67.39L14 13.83c-.01.1-.1.17-.2.17h-1.6c-.1 0-.18-.07-.2-.17l-.15-1.06c-.25-.1-.47-.23-.68-.39l-.99.4c-.09.03-.2 0-.25-.09l-.8-1.39c-.05-.08-.03-.19.05-.25l.84-.66c-.01-.13-.02-.26-.02-.39s.02-.27.04-.39l-.85-.66c-.08-.06-.1-.16-.05-.26l.8-1.38c.05-.09.15-.12.24-.09l1 .4c.2-.15.43-.29.67-.39L12 6.17c.02-.1.1-.17.2-.17h1.6c.1 0 .18.07.2.17l.15 1.06c.24.1.46.23.67.39l1-.4c.09-.03.2 0 .24.09l.8 1.38c.05.09.03.2-.05.26l-.85.66c.03.12.04.25.04.39"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                  >
+                    Emotion detection you can trust
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Blend self-reported mood with contextual signals for accuracy.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="reveal reveal-delay-2 MuiBox-root css-11coye2 is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="GraphicEqIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M7 18h2V6H7zm4 4h2V2h-2zm-8-8h2v-4H3zm12 4h2V6h-2zm4-8v4h2v-4z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                  >
+                    Real-time music intelligence
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Adaptive recommendations keep pace with your day.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="reveal reveal-delay-3 MuiBox-root css-11coye2 is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="InsightsIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M21 8c-1.45 0-2.26 1.44-1.93 2.51l-3.55 3.56c-.3-.09-.74-.09-1.04 0l-2.55-2.55C12.27 10.45 11.46 9 10 9c-1.45 0-2.27 1.44-1.93 2.52l-4.56 4.55C2.44 15.74 1 16.55 1 18c0 1.1.9 2 2 2 1.45 0 2.26-1.44 1.93-2.51l4.55-4.56c.3.09.74.09 1.04 0l2.55 2.55C12.73 16.55 13.54 18 15 18c1.45 0 2.27-1.44 1.93-2.52l3.56-3.55c1.07.33 2.51-.48 2.51-1.93 0-1.1-.9-2-2-2"
+                    />
+                    <path
+                      d="m15 9 .94-2.07L18 6l-2.06-.93L15 3l-.92 2.07L12 6l2.08.93zM3.5 11 4 9l2-.5L4 8l-.5-2L3 8l-2 .5L3 9z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                  >
+                    Personal insights
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Understand how music influences your focus and energy.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 reveal reveal-delay-2 css-1fyyp8j-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijy44j-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Mood Spectrum
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  See how Moodify interprets your emotional blend in real time.
+                </p>
+                <div
+                  class="MuiStack-root css-wanzkd-MuiStack-root"
+                >
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiStack-root css-3y1137-MuiStack-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                      >
+                        Relaxed
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                      >
+                        76%
+                      </span>
+                    </div>
+                    <span
+                      aria-valuemax="100"
+                      aria-valuemin="0"
+                      aria-valuenow="76"
+                      class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-b1cuxi-MuiLinearProgress-root"
+                      role="progressbar"
+                    >
+                      <span
+                        class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                        style="transform: translateX(-24%);"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiStack-root css-3y1137-MuiStack-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                      >
+                        Focused
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                      >
+                        68%
+                      </span>
+                    </div>
+                    <span
+                      aria-valuemax="100"
+                      aria-valuemin="0"
+                      aria-valuenow="68"
+                      class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-b1cuxi-MuiLinearProgress-root"
+                      role="progressbar"
+                    >
+                      <span
+                        class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                        style="transform: translateX(-32%);"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiStack-root css-3y1137-MuiStack-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                      >
+                        Motivated
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                      >
+                        61%
+                      </span>
+                    </div>
+                    <span
+                      aria-valuemax="100"
+                      aria-valuemin="0"
+                      aria-valuenow="61"
+                      class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-b1cuxi-MuiLinearProgress-root"
+                      role="progressbar"
+                    >
+                      <span
+                        class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                        style="transform: translateX(-39%);"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiStack-root css-3y1137-MuiStack-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                      >
+                        Joyful
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                      >
+                        83%
+                      </span>
+                    </div>
+                    <span
+                      aria-valuemax="100"
+                      aria-valuemin="0"
+                      aria-valuenow="83"
+                      class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-b1cuxi-MuiLinearProgress-root"
+                      role="progressbar"
+                    >
+                      <span
+                        class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                        style="transform: translateX(-17%);"
+                      />
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-yo84df"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-2zizl3-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-5 reveal reveal-delay-1 css-urj5pv-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <h4
+              class="MuiTypography-root MuiTypography-h4 css-okodwh-MuiTypography-root"
+            >
+              Precision you can feel
+            </h4>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1a6ve4e-MuiTypography-root"
+            >
+              Every Moodify moment is tuned for responsiveness and clarity. Our signal pipeline balances speed, accuracy, and user control with transparent feedback you can trust.
+            </p>
+            <div
+              class="MuiStack-root css-10kbc59-MuiStack-root"
+            >
+              <div
+                class="reveal reveal-delay-1 MuiBox-root css-11coye2 is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="TimelineIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M23 8c0 1.1-.9 2-2 2-.18 0-.35-.02-.51-.07l-3.56 3.55c.05.16.07.34.07.52 0 1.1-.9 2-2 2s-2-.9-2-2c0-.18.02-.36.07-.52l-2.55-2.55c-.16.05-.34.07-.52.07s-.36-.02-.52-.07l-4.55 4.56c.05.16.07.33.07.51 0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2c.18 0 .35.02.51.07l4.56-4.55C8.02 9.36 8 9.18 8 9c0-1.1.9-2 2-2s2 .9 2 2c0 .18-.02.36-.07.52l2.55 2.55c.16-.05.34-.07.52-.07s.36.02.52.07l3.55-3.56C19.02 8.35 19 8.18 19 8c0-1.1.9-2 2-2s2 .9 2 2"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                  >
+                    Instant feedback loops
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Live updates show how your mood mix is changing.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="reveal reveal-delay-2 MuiBox-root css-11coye2 is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="QueryStatsIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19.88 18.47c.44-.7.7-1.51.7-2.39 0-2.49-2.01-4.5-4.5-4.5s-4.5 2.01-4.5 4.5 2.01 4.5 4.49 4.5c.88 0 1.7-.26 2.39-.7L21.58 23 23 21.58zm-3.8.11c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5m-.36-8.5c-.74.02-1.45.18-2.1.45l-.55-.83-3.8 6.18-3.01-3.52-3.63 5.81L1 17l5-8 3 3.5L13 6zm2.59.5c-.64-.28-1.33-.45-2.05-.49L21.38 2 23 3.18z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                  >
+                    Mood confidence scores
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Clear guidance on what the engine is sensing.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="reveal reveal-delay-3 MuiBox-root css-11coye2 is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="PublicIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m-1 17.93c-3.95-.49-7-3.85-7-7.93 0-.62.08-1.21.21-1.79L9 15v1c0 1.1.9 2 2 2zm6.9-2.54c-.26-.81-1-1.39-1.9-1.39h-1v-3c0-.55-.45-1-1-1H8v-2h2c.55 0 1-.45 1-1V7h2c1.1 0 2-.9 2-2v-.41c2.93 1.19 5 4.06 5 7.41 0 2.08-.8 3.97-2.1 5.39"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                  >
+                    Global listening graph
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Tune into shared mood patterns across regions.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 reveal reveal-delay-2 css-1a4ufwv-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijy44j-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Signal performance
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Real-time health metrics across the Moodify pipeline.
+                </p>
+                <div
+                  class="MuiStack-root css-1lu6d3e-MuiStack-root"
+                >
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiStack-root css-3y1137-MuiStack-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                      >
+                        Emotion accuracy
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                      >
+                        <span>
+                          93.4%
+                        </span>
+                      </span>
+                    </div>
+                    <span
+                      aria-valuemax="100"
+                      aria-valuemin="0"
+                      aria-valuenow="93"
+                      class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-w4ksgr-MuiLinearProgress-root"
+                      role="progressbar"
+                    >
+                      <span
+                        class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                        style="transform: translateX(-7%);"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiStack-root css-3y1137-MuiStack-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                      >
+                        Response latency
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                      >
+                        <span>
+                          120ms
+                        </span>
+                      </span>
+                    </div>
+                    <span
+                      aria-valuemax="100"
+                      aria-valuemin="0"
+                      aria-valuenow="82"
+                      class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-w4ksgr-MuiLinearProgress-root"
+                      role="progressbar"
+                    >
+                      <span
+                        class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                        style="transform: translateX(-18%);"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiStack-root css-3y1137-MuiStack-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                      >
+                        Adaptive refresh rate
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                      >
+                        <span>
+                          6x/hr
+                        </span>
+                      </span>
+                    </div>
+                    <span
+                      aria-valuemax="100"
+                      aria-valuemin="0"
+                      aria-valuenow="70"
+                      class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-w4ksgr-MuiLinearProgress-root"
+                      role="progressbar"
+                    >
+                      <span
+                        class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                        style="transform: translateX(-30%);"
+                      />
+                    </span>
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <div
+                      class="MuiStack-root css-3y1137-MuiStack-root"
+                    >
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1uj910n-MuiTypography-root"
+                      >
+                        Daily mood journaling
+                      </span>
+                      <span
+                        class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                      >
+                        <span>
+                          14 days
+                        </span>
+                      </span>
+                    </div>
+                    <span
+                      aria-valuemax="100"
+                      aria-valuemin="0"
+                      aria-valuenow="64"
+                      class="MuiLinearProgress-root MuiLinearProgress-colorPrimary MuiLinearProgress-determinate css-w4ksgr-MuiLinearProgress-root"
+                      role="progressbar"
+                    >
+                      <span
+                        class="MuiLinearProgress-bar MuiLinearProgress-bar1 MuiLinearProgress-barColorPrimary MuiLinearProgress-bar1Determinate css-l16vtb-MuiLinearProgress-bar1"
+                        style="transform: translateX(-36%);"
+                      />
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-71tj1p"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="reveal reveal-delay-1 MuiBox-root css-1pvqgwb is-visible"
+          data-reveal="true"
+        >
+          <span
+            class="MuiBox-root css-imdgq3"
+          >
+            Capabilities
+          </span>
+        </div>
+        <h4
+          class="MuiTypography-root MuiTypography-h4 reveal reveal-delay-1 css-1huxlzc-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Features
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-1lk3woo-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Professional-grade tools that stay intuitive for every listener.
+        </p>
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-1 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1lxsylr-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-yx8atr"
+                >
+                  <div
+                    class="MuiBox-root css-k400sw"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="AutoAwesomeIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m19 9 1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25z"
+                      />
+                    </svg>
+                  </div>
+                  <h6
+                    class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                  >
+                    Mood-Matched Music
+                  </h6>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Get playlists tailored to your emotional state in real time.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-2 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1lxsylr-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-yx8atr"
+                >
+                  <div
+                    class="MuiBox-root css-k400sw"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="TextsmsIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M20 2H4c-1.1 0-1.99.9-1.99 2L2 22l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2M9 11H7V9h2zm4 0h-2V9h2zm4 0h-2V9h2z"
+                      />
+                    </svg>
+                  </div>
+                  <h6
+                    class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                  >
+                    Multi-Input Mood Capture
+                  </h6>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Share your feelings via text, voice, or camera input.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-3 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1lxsylr-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-yx8atr"
+                >
+                  <div
+                    class="MuiBox-root css-k400sw"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="TuneIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M3 17v2h6v-2zM3 5v2h10V5zm10 16v-2h8v-2h-8v-2h-2v6zM7 9v2H3v2h4v2h2V9zm14 4v-2H11v2zm-6-4h2V7h4V5h-4V3h-2z"
+                      />
+                    </svg>
+                  </div>
+                  <h6
+                    class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                  >
+                    Adaptive Listening Engine
+                  </h6>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Moodify adjusts your soundtrack as your energy shifts.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-1 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1lxsylr-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-yx8atr"
+                >
+                  <div
+                    class="MuiBox-root css-k400sw"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="InsightsIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M21 8c-1.45 0-2.26 1.44-1.93 2.51l-3.55 3.56c-.3-.09-.74-.09-1.04 0l-2.55-2.55C12.27 10.45 11.46 9 10 9c-1.45 0-2.27 1.44-1.93 2.52l-4.56 4.55C2.44 15.74 1 16.55 1 18c0 1.1.9 2 2 2 1.45 0 2.26-1.44 1.93-2.51l4.55-4.56c.3.09.74.09 1.04 0l2.55 2.55C12.73 16.55 13.54 18 15 18c1.45 0 2.27-1.44 1.93-2.52l3.56-3.55c1.07.33 2.51-.48 2.51-1.93 0-1.1-.9-2-2-2"
+                      />
+                      <path
+                        d="m15 9 .94-2.07L18 6l-2.06-.93L15 3l-.92 2.07L12 6l2.08.93zM3.5 11 4 9l2-.5L4 8l-.5-2L3 8l-2 .5L3 9z"
+                      />
+                    </svg>
+                  </div>
+                  <h6
+                    class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                  >
+                    Personal Mood Insights
+                  </h6>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Track mood patterns and understand music impact.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-2 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1lxsylr-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-yx8atr"
+                >
+                  <div
+                    class="MuiBox-root css-k400sw"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="HeadphonesIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 3c-4.97 0-9 4.03-9 9v7c0 1.1.9 2 2 2h4v-8H5v-1c0-3.87 3.13-7 7-7s7 3.13 7 7v1h-4v8h4c1.1 0 2-.9 2-2v-7c0-4.97-4.03-9-9-9"
+                      />
+                    </svg>
+                  </div>
+                  <h6
+                    class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                  >
+                    Focus & Flow Modes
+                  </h6>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Curated sessions for deep work, study, or creativity.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-3 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1lxsylr-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-yx8atr"
+                >
+                  <div
+                    class="MuiBox-root css-k400sw"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="ShareIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92"
+                      />
+                    </svg>
+                  </div>
+                  <h6
+                    class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                  >
+                    Social Sharing
+                  </h6>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Share mood journeys and playlists with your circle.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-1 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1lxsylr-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-yx8atr"
+                >
+                  <div
+                    class="MuiBox-root css-k400sw"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="CloudSyncIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M21.5 14.98c-.02 0-.03 0-.05.01C21.2 13.3 19.76 12 18 12c-1.4 0-2.6.83-3.16 2.02C13.26 14.1 12 15.4 12 17c0 1.66 1.34 3 3 3l6.5-.02c1.38 0 2.5-1.12 2.5-2.5s-1.12-2.5-2.5-2.5M10 4.26v2.09C7.67 7.18 6 9.39 6 12c0 1.77.78 3.34 2 4.44V14h2v6H4v-2h2.73C5.06 16.54 4 14.4 4 12c0-3.73 2.55-6.85 6-7.74M20 6h-2.73c1.43 1.26 2.41 3.01 2.66 5h-2.02c-.23-1.36-.93-2.55-1.91-3.44V10h-2V4h6z"
+                      />
+                    </svg>
+                  </div>
+                  <h6
+                    class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                  >
+                    Cloud Sync
+                  </h6>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Stay consistent across devices with secure sync.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-2 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1lxsylr-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-yx8atr"
+                >
+                  <div
+                    class="MuiBox-root css-k400sw"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="FavoriteIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="m12 21.35-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54z"
+                      />
+                    </svg>
+                  </div>
+                  <h6
+                    class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                  >
+                    Feel-Good Favorites
+                  </h6>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Save playlists that always lift your mood.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-yo84df"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="reveal reveal-delay-1 MuiBox-root css-1pvqgwb is-visible"
+          data-reveal="true"
+        >
+          <span
+            class="MuiBox-root css-imdgq3"
+          >
+            The experience
+          </span>
+        </div>
+        <h4
+          class="MuiTypography-root MuiTypography-h4 reveal reveal-delay-1 css-1huxlzc-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Inside Moodify
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-1lk3woo-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          A curated experience built on emotional clarity, adaptive listening, and thoughtful rituals.
+        </p>
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4 reveal reveal-delay-1 css-1lj5egr-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="QueryStatsIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19.88 18.47c.44-.7.7-1.51.7-2.39 0-2.49-2.01-4.5-4.5-4.5s-4.5 2.01-4.5 4.5 2.01 4.5 4.49 4.5c.88 0 1.7-.26 2.39-.7L21.58 23 23 21.58zm-3.8.11c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5m-.36-8.5c-.74.02-1.45.18-2.1.45l-.55-.83-3.8 6.18-3.01-3.52-3.63 5.81L1 17l5-8 3 3.5L13 6zm2.59.5c-.64-.28-1.33-.45-2.05-.49L21.38 2 23 3.18z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Emotion Graph
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Map your mood patterns with a personalized emotional fingerprint.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4 reveal reveal-delay-2 css-1lj5egr-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="AutoAwesomeIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m19 9 1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Adaptive Curation
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Playlists evolve as your energy shifts, without disrupting flow.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4 reveal reveal-delay-3 css-1lj5egr-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="EmojiEventsIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5h-2V3H7v2H5c-1.1 0-2 .9-2 2v1c0 2.55 1.92 4.63 4.39 4.94.63 1.5 1.98 2.63 3.61 2.96V19H7v2h10v-2h-4v-3.1c1.63-.33 2.98-1.46 3.61-2.96C19.08 12.63 21 10.55 21 8V7c0-1.1-.9-2-2-2M5 8V7h2v3.82C5.84 10.4 5 9.3 5 8m14 0c0 1.3-.84 2.4-2 2.82V7h2z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Listening Rituals
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Build recurring routines for focus, calm, or confidence.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-71tj1p"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="reveal reveal-delay-1 MuiBox-root css-1pvqgwb is-visible"
+          data-reveal="true"
+        >
+          <span
+            class="MuiBox-root css-imdgq3"
+          >
+            How it works
+          </span>
+        </div>
+        <h4
+          class="MuiTypography-root MuiTypography-h4 reveal reveal-delay-1 css-1huxlzc-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          How Moodify Works
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-1lk3woo-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          A guided flow that keeps your experience smooth, accessible, and deeply personalized.
+        </p>
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-3 reveal reveal-delay-1 css-iv7vbz-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-1gv8ke5"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="CameraAltIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      cx="12"
+                      cy="12"
+                      r="3.2"
+                    />
+                    <path
+                      d="M9 2 7.17 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2h-3.17L15 2zm3 15c-2.76 0-5-2.24-5-5s2.24-5 5-5 5 2.24 5 5-2.24 5-5 5"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Check in
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Tell Moodify how you feel using any input method.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-3 reveal reveal-delay-2 css-iv7vbz-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-1gv8ke5"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="AutoAwesomeIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m19 9 1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Analyze
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Our engine interprets your emotional context instantly.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-3 reveal reveal-delay-3 css-iv7vbz-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-1gv8ke5"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="HeadphonesIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 3c-4.97 0-9 4.03-9 9v7c0 1.1.9 2 2 2h4v-8H5v-1c0-3.87 3.13-7 7-7s7 3.13 7 7v1h-4v8h4c1.1 0 2-.9 2-2v-7c0-4.97-4.03-9-9-9"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Listen
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Enjoy a soundtrack designed to match and elevate your mood.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-3 reveal reveal-delay-1 css-iv7vbz-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-1gv8ke5"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="InsightsIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M21 8c-1.45 0-2.26 1.44-1.93 2.51l-3.55 3.56c-.3-.09-.74-.09-1.04 0l-2.55-2.55C12.27 10.45 11.46 9 10 9c-1.45 0-2.27 1.44-1.93 2.52l-4.56 4.55C2.44 15.74 1 16.55 1 18c0 1.1.9 2 2 2 1.45 0 2.26-1.44 1.93-2.51l4.55-4.56c.3.09.74.09 1.04 0l2.55 2.55C12.73 16.55 13.54 18 15 18c1.45 0 2.27-1.44 1.93-2.52l3.56-3.55c1.07.33 2.51-.48 2.51-1.93 0-1.1-.9-2-2-2"
+                    />
+                    <path
+                      d="m15 9 .94-2.07L18 6l-2.06-.93L15 3l-.92 2.07L12 6l2.08.93zM3.5 11 4 9l2-.5L4 8l-.5-2L3 8l-2 .5L3 9z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Reflect
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Review mood journeys and adjust preferences anytime.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-yo84df"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="reveal reveal-delay-1 MuiBox-root css-1pvqgwb is-visible"
+          data-reveal="true"
+        >
+          <span
+            class="MuiBox-root css-imdgq3"
+          >
+            Real results
+          </span>
+        </div>
+        <h4
+          class="MuiTypography-root MuiTypography-h4 reveal reveal-delay-1 css-1huxlzc-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Listening outcomes
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-1lk3woo-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Mindful sessions and productive routines that listeners rely on.
+        </p>
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-1 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h4
+                  class="MuiTypography-root MuiTypography-h4 css-1w02n9d-MuiTypography-root"
+                >
+                  <span>
+                    42%
+                  </span>
+                </h4>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Focus lift
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Listeners report deeper flow sessions.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-2 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h4
+                  class="MuiTypography-root MuiTypography-h4 css-1w02n9d-MuiTypography-root"
+                >
+                  <span>
+                    28%
+                  </span>
+                </h4>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Stress reduction
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Mood-calming playlists used daily.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-3 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h4
+                  class="MuiTypography-root MuiTypography-h4 css-1w02n9d-MuiTypography-root"
+                >
+                  <span>
+                    3.4x
+                  </span>
+                </h4>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Session retention
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Average session extension with mood sync.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-1 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h4
+                  class="MuiTypography-root MuiTypography-h4 css-1w02n9d-MuiTypography-root"
+                >
+                  <span>
+                    5+
+                  </span>
+                </h4>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Weekly rituals
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Personal routines saved per listener.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-71tj1p"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="reveal reveal-delay-1 MuiBox-root css-1pvqgwb is-visible"
+          data-reveal="true"
+        >
+          <span
+            class="MuiBox-root css-imdgq3"
+          >
+            Use cases
+          </span>
+        </div>
+        <h4
+          class="MuiTypography-root MuiTypography-h4 reveal reveal-delay-1 css-1huxlzc-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Built for Every Moment
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-1lk3woo-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Moodify adapts to the settings you care about most, from work and study to wellness and creative flow.
+        </p>
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-1 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="WorkIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 6h-4V4c0-1.11-.89-2-2-2h-4c-1.11 0-2 .89-2 2v2H4c-1.11 0-1.99.89-1.99 2L2 19c0 1.11.89 2 2 2h16c1.11 0 2-.89 2-2V8c0-1.11-.89-2-2-2m-6 0h-4V4h4z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Focused Work
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Stay in the zone with distraction-free soundscapes.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-2 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="SchoolIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M5 13.18v4L12 21l7-3.82v-4L12 17zM12 3 1 9l11 6 9-4.91V17h2V9z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Study Sessions
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Maintain clarity and retention with calming tracks.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-3 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="FitnessCenterIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20.57 14.86 22 13.43 20.57 12 17 15.57 8.43 7 12 3.43 10.57 2 9.14 3.43 7.71 2 5.57 4.14 4.14 2.71 2.71 4.14l1.43 1.43L2 7.71l1.43 1.43L2 10.57 3.43 12 7 8.43 15.57 17 12 20.57 13.43 22l1.43-1.43L16.29 22l2.14-2.14 1.43 1.43 1.43-1.43-1.43-1.43L22 16.29z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Fitness Boost
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Find the tempo that pushes you through your workout.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-1 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="SelfImprovementIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      cx="12"
+                      cy="6"
+                      r="2"
+                    />
+                    <path
+                      d="M21 16v-2c-2.24 0-4.16-.96-5.6-2.68l-1.34-1.6c-.38-.46-.94-.72-1.53-.72h-1.05c-.59 0-1.15.26-1.53.72l-1.34 1.6C7.16 13.04 5.24 14 3 14v2c2.77 0 5.19-1.17 7-3.25V15l-3.88 1.55c-.67.27-1.12.93-1.12 1.66C5 19.2 5.8 20 6.79 20H9v-.5c0-1.38 1.12-2.5 2.5-2.5h3c.28 0 .5.22.5.5s-.22.5-.5.5h-3c-.83 0-1.5.67-1.5 1.5v.5h7.21c.99 0 1.79-.8 1.79-1.79 0-.73-.45-1.39-1.12-1.66L14 15v-2.25c1.81 2.08 4.23 3.25 7 3.25"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Mindful Breaks
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Reset your nervous system with gentle audio rituals.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-2 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="NightlightIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M14 2c1.82 0 3.53.5 5 1.35-2.99 1.73-5 4.95-5 8.65s2.01 6.92 5 8.65c-1.47.85-3.18 1.35-5 1.35-5.52 0-10-4.48-10-10S8.48 2 14 2"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Evening Wind-Down
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Transition into rest with soft nighttime playlists.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-3 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="LocalCafeIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 3H4v10c0 2.21 1.79 4 4 4h6c2.21 0 4-1.79 4-4v-3h2c1.11 0 2-.9 2-2V5c0-1.11-.89-2-2-2m0 5h-2V5h2zM4 19h16v2H4z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Creative Flow
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Spark ideas with cinematic and ambient moods.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-yo84df"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="reveal reveal-delay-1 MuiBox-root css-1pvqgwb is-visible"
+          data-reveal="true"
+        >
+          <span
+            class="MuiBox-root css-imdgq3"
+          >
+            Playlists
+          </span>
+        </div>
+        <h4
+          class="MuiTypography-root MuiTypography-h4 reveal reveal-delay-1 css-1huxlzc-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Curated Mood Journeys
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-1lk3woo-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Save, revisit, and share playlists that evolve with your emotional rhythm.
+        </p>
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-1 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-overline css-1gmuzu9-MuiTypography-root"
+                >
+                  30 min
+                </span>
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                >
+                  Calm Morning Reset
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Breathe into your day with gentle acoustic and ambient tones.
+                </p>
+                <div
+                  class="MuiStack-root css-1nh9prl-MuiStack-root"
+                >
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Calm
+                    </span>
+                  </div>
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Soft Focus
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-2 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-overline css-1gmuzu9-MuiTypography-root"
+                >
+                  45 min
+                </span>
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                >
+                  Deep Work Sprint
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Instrumental rhythms built for sustained concentration.
+                </p>
+                <div
+                  class="MuiStack-root css-1nh9prl-MuiStack-root"
+                >
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Focus
+                    </span>
+                  </div>
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Flow
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-3 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-overline css-1gmuzu9-MuiTypography-root"
+                >
+                  25 min
+                </span>
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                >
+                  Mood Lift
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Bright, uplifting tracks that elevate energy and optimism.
+                </p>
+                <div
+                  class="MuiStack-root css-1nh9prl-MuiStack-root"
+                >
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Uplift
+                    </span>
+                  </div>
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Energy
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-1 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-overline css-1gmuzu9-MuiTypography-root"
+                >
+                  40 min
+                </span>
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                >
+                  Creative Studio
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Layered textures and cinematic soundscapes for ideation.
+                </p>
+                <div
+                  class="MuiStack-root css-1nh9prl-MuiStack-root"
+                >
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Creativity
+                    </span>
+                  </div>
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Inspire
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-2 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-overline css-1gmuzu9-MuiTypography-root"
+                >
+                  35 min
+                </span>
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                >
+                  Evening Unwind
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Slow it down with warm vocals and mellow instrumentals.
+                </p>
+                <div
+                  class="MuiStack-root css-1nh9prl-MuiStack-root"
+                >
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Relax
+                    </span>
+                  </div>
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Night
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-3 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <span
+                  class="MuiTypography-root MuiTypography-overline css-1gmuzu9-MuiTypography-root"
+                >
+                  20 min
+                </span>
+                <h6
+                  class="MuiTypography-root MuiTypography-h6 css-8exp8-MuiTypography-root"
+                >
+                  Energy Boost
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  High-tempo momentum when you need a quick recharge.
+                </p>
+                <div
+                  class="MuiStack-root css-1nh9prl-MuiStack-root"
+                >
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Motivation
+                    </span>
+                  </div>
+                  <div
+                    class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-10nu2dl-MuiChip-root"
+                  >
+                    <span
+                      class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                    >
+                      Pulse
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-71tj1p"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-2zizl3-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-5 reveal reveal-delay-1 css-urj5pv-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <h4
+              class="MuiTypography-root MuiTypography-h4 css-okodwh-MuiTypography-root"
+            >
+              Seamless across devices and services
+            </h4>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1a6ve4e-MuiTypography-root"
+            >
+              Moodify connects with the tools you already use so your playlists and routines stay consistent across sessions.
+            </p>
+            <div
+              class="MuiStack-root css-d39g6e-MuiStack-root"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-a3a136-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                >
+                  Smart speakers
+                </span>
+              </div>
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-a3a136-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                >
+                  Wearables
+                </span>
+              </div>
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-a3a136-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                >
+                  Wellness platforms
+                </span>
+              </div>
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-a3a136-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                >
+                  Calendar sync
+                </span>
+              </div>
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-a3a136-MuiChip-root"
+              >
+                <span
+                  class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                >
+                  Team spaces
+                </span>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 reveal reveal-delay-2 css-1a4ufwv-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-11nsb57-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-1 css-11l5t4l-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-rtee8u-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Streaming Sync
+                    </h6>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                    >
+                      Keep favorites aligned across devices and sessions.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-2 css-11l5t4l-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-rtee8u-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Calendar Focus
+                    </h6>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                    >
+                      Auto-launch focus playlists with your schedule.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-3 css-11l5t4l-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-rtee8u-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Wearables
+                    </h6>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                    >
+                      Adapt playlists based on heart rate and activity.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-1 css-11l5t4l-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-rtee8u-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Smart Speakers
+                    </h6>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                    >
+                      Voice-controlled mood changes at home.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-2 css-11l5t4l-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-rtee8u-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Collaboration
+                    </h6>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                    >
+                      Share moods and playlists with your team.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-3 css-11l5t4l-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-rtee8u-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Wellness Apps
+                    </h6>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                    >
+                      Blend music into mindful routines and journaling.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-1 css-11l5t4l-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-rtee8u-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Focus Tools
+                    </h6>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                    >
+                      Pair Moodify with timers and productivity stacks.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-2 css-11l5t4l-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-rtee8u-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Health Platforms
+                    </h6>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                    >
+                      Integrate mood data with wellness insights.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-3 css-11l5t4l-MuiGrid-root is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-rtee8u-MuiPaper-root-MuiCard-root"
+                  style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+                >
+                  <div
+                    class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Social Sharing
+                    </h6>
+                    <p
+                      class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                    >
+                      Easily share your mood journeys with friends.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-yo84df"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-4 css-2zizl3-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 reveal reveal-delay-1 css-1fyyp8j-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <h4
+              class="MuiTypography-root MuiTypography-h4 css-okodwh-MuiTypography-root"
+            >
+              Universal design, built in
+            </h4>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1a6ve4e-MuiTypography-root"
+            >
+              We designed Moodify to be welcoming for every listener with clarity, comfort, and accessibility at the core.
+            </p>
+            <div
+              class="MuiStack-root css-1sazv7p-MuiStack-root"
+            >
+              <div
+                class="reveal reveal-delay-1 MuiBox-root css-11coye2 is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="AccessibilityNewIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20.5 6c-2.61.7-5.67 1-8.5 1s-5.89-.3-8.5-1L3 8c1.86.5 4 .83 6 1v13h2v-6h2v6h2V9c2-.17 4.14-.5 6-1zM12 6c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                  >
+                    High-contrast modes
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Legible color systems for light and dark environments.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="reveal reveal-delay-2 MuiBox-root css-11coye2 is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="MicIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 14c1.66 0 2.99-1.34 2.99-3L15 5c0-1.66-1.34-3-3-3S9 3.34 9 5v6c0 1.66 1.34 3 3 3m5.3-3c0 3-2.54 5.1-5.3 5.1S6.7 14 6.7 11H5c0 3.41 2.72 6.23 6 6.72V21h2v-3.28c3.28-.48 6-3.3 6-6.72z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                  >
+                    Voice-first navigation
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Hands-free listening for focus and mobility needs.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="reveal reveal-delay-3 MuiBox-root css-11coye2 is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="TuneIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M3 17v2h6v-2zM3 5v2h10V5zm10 16v-2h8v-2h-8v-2h-2v6zM7 9v2H3v2h4v2h2V9zm14 4v-2H11v2zm-6-4h2V7h4V5h-4V3h-2z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                  >
+                    Reduced motion support
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Gentle animations to support comfort and focus.
+                  </p>
+                </div>
+              </div>
+              <div
+                class="reveal reveal-delay-1 MuiBox-root css-11coye2 is-visible"
+                data-reveal="true"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="GroupIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M16 11c1.66 0 2.99-1.34 2.99-3S17.66 5 16 5s-3 1.34-3 3 1.34 3 3 3m-8 0c1.66 0 2.99-1.34 2.99-3S9.66 5 8 5 5 6.34 5 8s1.34 3 3 3m0 2c-2.33 0-7 1.17-7 3.5V19h14v-2.5c0-2.33-4.67-3.5-7-3.5m8 0c-.29 0-.62.02-.97.05 1.16.84 1.97 1.97 1.97 3.45V19h6v-2.5c0-2.33-4.67-3.5-7-3.5"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                  >
+                    Clear layout hierarchy
+                  </h6>
+                  <p
+                    class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                  >
+                    Predictable spacing, typography, and structure.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 reveal reveal-delay-2 css-1fyyp8j-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijy44j-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Privacy and trust
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Your emotions stay yours. Moodify uses privacy-first design and secure processing to keep your data safe.
+                </p>
+                <div
+                  class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1gzbshf-MuiGrid-root"
+                >
+                  <div
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 reveal reveal-delay-1 css-1b3l6lk-MuiGrid-root is-visible"
+                    data-reveal="true"
+                  >
+                    <div
+                      class="MuiBox-root css-yy3chv"
+                    >
+                      <div
+                        class="MuiBox-root css-k400sw"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                          data-testid="SecurityIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 1 3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5zm0 10.99h7c-.53 4.12-3.28 7.79-7 8.94V12H5V6.3l7-3.11z"
+                          />
+                        </svg>
+                      </div>
+                      <h6
+                        class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                      >
+                        Secure processing
+                      </h6>
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                      >
+                        Protected pipelines for sensitive emotional data.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 reveal reveal-delay-2 css-1b3l6lk-MuiGrid-root is-visible"
+                    data-reveal="true"
+                  >
+                    <div
+                      class="MuiBox-root css-yy3chv"
+                    >
+                      <div
+                        class="MuiBox-root css-k400sw"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                          data-testid="VerifiedUserIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 1 3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5zm-2 16-4-4 1.41-1.41L10 14.17l6.59-6.59L18 9z"
+                          />
+                        </svg>
+                      </div>
+                      <h6
+                        class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                      >
+                        Privacy-first
+                      </h6>
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                      >
+                        You choose what is shared and saved.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 reveal reveal-delay-3 css-1b3l6lk-MuiGrid-root is-visible"
+                    data-reveal="true"
+                  >
+                    <div
+                      class="MuiBox-root css-yy3chv"
+                    >
+                      <div
+                        class="MuiBox-root css-k400sw"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                          data-testid="PsychologyIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M13 8.57c-.79 0-1.43.64-1.43 1.43s.64 1.43 1.43 1.43 1.43-.64 1.43-1.43-.64-1.43-1.43-1.43"
+                          />
+                          <path
+                            d="M13 3C9.25 3 6.2 5.94 6.02 9.64L4.1 12.2c-.25.33-.01.8.4.8H6v3c0 1.1.9 2 2 2h1v3h7v-4.68c2.36-1.12 4-3.53 4-6.32 0-3.87-3.13-7-7-7m3 7c0 .13-.01.26-.02.39l.83.66c.08.06.1.16.05.25l-.8 1.39c-.05.09-.16.12-.24.09l-.99-.4c-.21.16-.43.29-.67.39L14 13.83c-.01.1-.1.17-.2.17h-1.6c-.1 0-.18-.07-.2-.17l-.15-1.06c-.25-.1-.47-.23-.68-.39l-.99.4c-.09.03-.2 0-.25-.09l-.8-1.39c-.05-.08-.03-.19.05-.25l.84-.66c-.01-.13-.02-.26-.02-.39s.02-.27.04-.39l-.85-.66c-.08-.06-.1-.16-.05-.26l.8-1.38c.05-.09.15-.12.24-.09l1 .4c.2-.15.43-.29.67-.39L12 6.17c.02-.1.1-.17.2-.17h1.6c.1 0 .18.07.2.17l.15 1.06c.24.1.46.23.67.39l1-.4c.09-.03.2 0 .24.09l.8 1.38c.05.09.03.2-.05.26l-.85.66c.03.12.04.25.04.39"
+                          />
+                        </svg>
+                      </div>
+                      <h6
+                        class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                      >
+                        Ethical AI
+                      </h6>
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                      >
+                        Transparent recommendations you can control.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 reveal reveal-delay-1 css-1b3l6lk-MuiGrid-root is-visible"
+                    data-reveal="true"
+                  >
+                    <div
+                      class="MuiBox-root css-yy3chv"
+                    >
+                      <div
+                        class="MuiBox-root css-k400sw"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                          data-testid="HeadphonesIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M12 3c-4.97 0-9 4.03-9 9v7c0 1.1.9 2 2 2h4v-8H5v-1c0-3.87 3.13-7 7-7s7 3.13 7 7v1h-4v8h4c1.1 0 2-.9 2-2v-7c0-4.97-4.03-9-9-9"
+                          />
+                        </svg>
+                      </div>
+                      <h6
+                        class="MuiTypography-root MuiTypography-subtitle2 css-frn8rq-MuiTypography-root"
+                      >
+                        Support ready
+                      </h6>
+                      <p
+                        class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                      >
+                        Guidance for teams and power listeners.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-71tj1p"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="reveal reveal-delay-1 MuiBox-root css-1pvqgwb is-visible"
+          data-reveal="true"
+        >
+          <span
+            class="MuiBox-root css-imdgq3"
+          >
+            Testimonials
+          </span>
+        </div>
+        <h4
+          class="MuiTypography-root MuiTypography-h4 reveal reveal-delay-1 css-1huxlzc-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          What Our Users Say
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-1lk3woo-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          From creators to wellness teams, Moodify brings emotional clarity to every playlist.
+        </p>
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-1 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiStack-root css-1sos3zc-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-m4x9fz-MuiAvatar-root"
+                  >
+                    RN
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Ricky Nguyen
+                    </h6>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      Creator
+                    </span>
+                  </div>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1uxwdxo-MuiTypography-root"
+                >
+                  “Moodify helps me dial in the exact vibe I need before recording.”
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-2 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiStack-root css-1sos3zc-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-m4x9fz-MuiAvatar-root"
+                  >
+                    KC
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Katarina Chen
+                    </h6>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      Wellness Coach
+                    </span>
+                  </div>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1uxwdxo-MuiTypography-root"
+                >
+                  “The mood journeys are perfect for guiding clients into calm.”
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-3 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiStack-root css-1sos3zc-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-m4x9fz-MuiAvatar-root"
+                  >
+                    AS
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Adam Smith
+                    </h6>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      Product Designer
+                    </span>
+                  </div>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1uxwdxo-MuiTypography-root"
+                >
+                  “I love the adaptive playlists for deep work sessions.”
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-1 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiStack-root css-1sos3zc-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-m4x9fz-MuiAvatar-root"
+                  >
+                    RL
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Richard Le
+                    </h6>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      Student
+                    </span>
+                  </div>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1uxwdxo-MuiTypography-root"
+                >
+                  “Moodify makes studying feel effortless and focused.”
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-2 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiStack-root css-1sos3zc-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-m4x9fz-MuiAvatar-root"
+                  >
+                    AN
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Amina Noor
+                    </h6>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      Team Lead
+                    </span>
+                  </div>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1uxwdxo-MuiTypography-root"
+                >
+                  “We use Moodify during team focus blocks and it just works.”
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-4 reveal reveal-delay-3 css-11l5t4l-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiStack-root css-1sos3zc-MuiStack-root"
+                >
+                  <div
+                    class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-m4x9fz-MuiAvatar-root"
+                  >
+                    LO
+                  </div>
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Luis Ortega
+                    </h6>
+                    <span
+                      class="MuiTypography-root MuiTypography-caption css-1kwgbyb-MuiTypography-root"
+                    >
+                      Fitness Coach
+                    </span>
+                  </div>
+                </div>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1uxwdxo-MuiTypography-root"
+                >
+                  “The energy playlists help my clients stay motivated.”
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-yo84df"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="reveal reveal-delay-1 MuiBox-root css-1pvqgwb is-visible"
+          data-reveal="true"
+        >
+          <span
+            class="MuiBox-root css-imdgq3"
+          >
+            Emotions
+          </span>
+        </div>
+        <h4
+          class="MuiTypography-root MuiTypography-h4 reveal reveal-delay-1 css-1huxlzc-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Emotions Moodify understands
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-1lk3woo-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          However you feel, there is a soundtrack for it. Here is how Moodify maps your mood to the right music.
+        </p>
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-3 css-1qw2a80-MuiGrid-root"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-1 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="EmojiEventsIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M19 5h-2V3H7v2H5c-1.1 0-2 .9-2 2v1c0 2.55 1.92 4.63 4.39 4.94.63 1.5 1.98 2.63 3.61 2.96V19H7v2h10v-2h-4v-3.1c1.63-.33 2.98-1.46 3.61-2.96C19.08 12.63 21 10.55 21 8V7c0-1.1-.9-2-2-2M5 8V7h2v3.82C5.84 10.4 5 9.3 5 8m14 0c0 1.3-.84 2.4-2 2.82V7h2z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Happy
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Upbeat pop and feel-good anthems
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-2 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="SelfImprovementIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      cx="12"
+                      cy="6"
+                      r="2"
+                    />
+                    <path
+                      d="M21 16v-2c-2.24 0-4.16-.96-5.6-2.68l-1.34-1.6c-.38-.46-.94-.72-1.53-.72h-1.05c-.59 0-1.15.26-1.53.72l-1.34 1.6C7.16 13.04 5.24 14 3 14v2c2.77 0 5.19-1.17 7-3.25V15l-3.88 1.55c-.67.27-1.12.93-1.12 1.66C5 19.2 5.8 20 6.79 20H9v-.5c0-1.38 1.12-2.5 2.5-2.5h3c.28 0 .5.22.5.5s-.22.5-.5.5h-3c-.83 0-1.5.67-1.5 1.5v.5h7.21c.99 0 1.79-.8 1.79-1.79 0-.73-.45-1.39-1.12-1.66L14 15v-2.25c1.81 2.08 4.23 3.25 7 3.25"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Calm
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Ambient, lo-fi and soft acoustics
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-3 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="BoltIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M11 21h-1l1-7H7.5c-.58 0-.57-.32-.38-.66s.05-.08.07-.12C8.48 10.94 10.42 7.54 13 3h1l-1 7h3.5c.49 0 .56.33.47.51l-.07.15C12.96 17.55 11 21 11 21"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Energetic
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  High-tempo electronic and dance
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-1 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="HeadphonesIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M12 3c-4.97 0-9 4.03-9 9v7c0 1.1.9 2 2 2h4v-8H5v-1c0-3.87 3.13-7 7-7s7 3.13 7 7v1h-4v8h4c1.1 0 2-.9 2-2v-7c0-4.97-4.03-9-9-9"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Focused
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Instrumental deep-focus beats
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-2 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="NightlightIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M14 2c1.82 0 3.53.5 5 1.35-2.99 1.73-5 4.95-5 8.65s2.01 6.92 5 8.65c-1.47.85-3.18 1.35-5 1.35-5.52 0-10-4.48-10-10S8.48 2 14 2"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Sad
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Mellow ballads and slow tracks
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-3 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="FitnessCenterIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20.57 14.86 22 13.43 20.57 12 17 15.57 8.43 7 12 3.43 10.57 2 9.14 3.43 7.71 2 5.57 4.14 4.14 2.71 2.71 4.14l1.43 1.43L2 7.71l1.43 1.43L2 10.57 3.43 12 7 8.43 15.57 17 12 20.57 13.43 22l1.43-1.43L16.29 22l2.14-2.14 1.43 1.43 1.43-1.43-1.43-1.43L22 16.29z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Confident
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Bold rock and strong vocals
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-1 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="LocalCafeIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M20 3H4v10c0 2.21 1.79 4 4 4h6c2.21 0 4-1.79 4-4v-3h2c1.11 0 2-.9 2-2V5c0-1.11-.89-2-2-2m0 5h-2V5h2zM4 19h16v2H4z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Relaxed
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Chillhop and warm jazz
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 reveal reveal-delay-2 css-10voxkt-MuiGrid-root is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-1ijuv82-MuiPaper-root-MuiCard-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <div
+                class="MuiCardContent-root css-1lt5qva-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-k400sw"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                    data-testid="FavoriteIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="m12 21.35-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54z"
+                    />
+                  </svg>
+                </div>
+                <h6
+                  class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                >
+                  Romantic
+                </h6>
+                <p
+                  class="MuiTypography-root MuiTypography-body2 css-1ek5k82-MuiTypography-root"
+                >
+                  Smooth R&B and dreamy indie
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-71tj1p"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthLg css-5c1adp-MuiContainer-root"
+      >
+        <div
+          class="reveal reveal-delay-1 MuiBox-root css-1pvqgwb is-visible"
+          data-reveal="true"
+        >
+          <span
+            class="MuiBox-root css-imdgq3"
+          >
+            FAQ
+          </span>
+        </div>
+        <h4
+          class="MuiTypography-root MuiTypography-h4 reveal reveal-delay-1 css-1huxlzc-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Frequently Asked Questions
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-1lk3woo-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Everything you need to know about getting started with Moodify.
+        </p>
+        <div
+          class="MuiStack-root css-1sazv7p-MuiStack-root"
+        >
+          <div
+            class="reveal reveal-delay-1 MuiBox-root css-0 is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-z9q64i-MuiPaper-root-MuiAccordion-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <h3
+                class="MuiAccordion-heading css-cy7rkm-MuiAccordion-heading"
+              >
+                <button
+                  aria-expanded="false"
+                  class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters css-1k1cj3j-MuiButtonBase-root-MuiAccordionSummary-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-yfrx4k-MuiAccordionSummary-content"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      How does Moodify understand my mood?
+                    </h6>
+                  </span>
+                  <span
+                    class="MuiAccordionSummary-expandIconWrapper css-1wqf3nl-MuiAccordionSummary-expandIconWrapper"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                      data-testid="ExpandMoreIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </h3>
+              <div
+                class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+                style="min-height: 0px;"
+              >
+                <div
+                  class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+                >
+                  <div
+                    class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+                  >
+                    <div
+                      class="MuiAccordion-region"
+                      role="region"
+                    >
+                      <div
+                        class="MuiAccordionDetails-root css-1f6346d-MuiAccordionDetails-root"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-1m7lbti-MuiTypography-root"
+                        >
+                          Moodify blends your input with contextual signals to interpret your current emotional state and recommend playlists that match your intent.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="reveal reveal-delay-2 MuiBox-root css-0 is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-z9q64i-MuiPaper-root-MuiAccordion-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <h3
+                class="MuiAccordion-heading css-cy7rkm-MuiAccordion-heading"
+              >
+                <button
+                  aria-expanded="false"
+                  class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters css-1k1cj3j-MuiButtonBase-root-MuiAccordionSummary-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-yfrx4k-MuiAccordionSummary-content"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Can I use Moodify without camera or voice input?
+                    </h6>
+                  </span>
+                  <span
+                    class="MuiAccordionSummary-expandIconWrapper css-1wqf3nl-MuiAccordionSummary-expandIconWrapper"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                      data-testid="ExpandMoreIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </h3>
+              <div
+                class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+                style="min-height: 0px;"
+              >
+                <div
+                  class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+                >
+                  <div
+                    class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+                  >
+                    <div
+                      class="MuiAccordion-region"
+                      role="region"
+                    >
+                      <div
+                        class="MuiAccordionDetails-root css-1f6346d-MuiAccordionDetails-root"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-1m7lbti-MuiTypography-root"
+                        >
+                          Yes. Text-based mood check-ins are always available and work seamlessly with the recommendation engine.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="reveal reveal-delay-3 MuiBox-root css-0 is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-z9q64i-MuiPaper-root-MuiAccordion-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <h3
+                class="MuiAccordion-heading css-cy7rkm-MuiAccordion-heading"
+              >
+                <button
+                  aria-expanded="false"
+                  class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters css-1k1cj3j-MuiButtonBase-root-MuiAccordionSummary-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-yfrx4k-MuiAccordionSummary-content"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Is Moodify available on mobile and desktop?
+                    </h6>
+                  </span>
+                  <span
+                    class="MuiAccordionSummary-expandIconWrapper css-1wqf3nl-MuiAccordionSummary-expandIconWrapper"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                      data-testid="ExpandMoreIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </h3>
+              <div
+                class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+                style="min-height: 0px;"
+              >
+                <div
+                  class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+                >
+                  <div
+                    class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+                  >
+                    <div
+                      class="MuiAccordion-region"
+                      role="region"
+                    >
+                      <div
+                        class="MuiAccordionDetails-root css-1f6346d-MuiAccordionDetails-root"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-1m7lbti-MuiTypography-root"
+                        >
+                          Moodify syncs across devices, so you can start a session on web and continue on mobile or desktop without losing context.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="reveal reveal-delay-1 MuiBox-root css-0 is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-z9q64i-MuiPaper-root-MuiAccordion-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <h3
+                class="MuiAccordion-heading css-cy7rkm-MuiAccordion-heading"
+              >
+                <button
+                  aria-expanded="false"
+                  class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters css-1k1cj3j-MuiButtonBase-root-MuiAccordionSummary-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-yfrx4k-MuiAccordionSummary-content"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Do I control what gets saved?
+                    </h6>
+                  </span>
+                  <span
+                    class="MuiAccordionSummary-expandIconWrapper css-1wqf3nl-MuiAccordionSummary-expandIconWrapper"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                      data-testid="ExpandMoreIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </h3>
+              <div
+                class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+                style="min-height: 0px;"
+              >
+                <div
+                  class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+                >
+                  <div
+                    class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+                  >
+                    <div
+                      class="MuiAccordion-region"
+                      role="region"
+                    >
+                      <div
+                        class="MuiAccordionDetails-root css-1f6346d-MuiAccordionDetails-root"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-1m7lbti-MuiTypography-root"
+                        >
+                          Absolutely. You decide which mood journeys or insights are stored, and you can remove them at any time.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="reveal reveal-delay-2 MuiBox-root css-0 is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-z9q64i-MuiPaper-root-MuiAccordion-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <h3
+                class="MuiAccordion-heading css-cy7rkm-MuiAccordion-heading"
+              >
+                <button
+                  aria-expanded="false"
+                  class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters css-1k1cj3j-MuiButtonBase-root-MuiAccordionSummary-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-yfrx4k-MuiAccordionSummary-content"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      Can teams use Moodify together?
+                    </h6>
+                  </span>
+                  <span
+                    class="MuiAccordionSummary-expandIconWrapper css-1wqf3nl-MuiAccordionSummary-expandIconWrapper"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                      data-testid="ExpandMoreIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </h3>
+              <div
+                class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+                style="min-height: 0px;"
+              >
+                <div
+                  class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+                >
+                  <div
+                    class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+                  >
+                    <div
+                      class="MuiAccordion-region"
+                      role="region"
+                    >
+                      <div
+                        class="MuiAccordionDetails-root css-1f6346d-MuiAccordionDetails-root"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-1m7lbti-MuiTypography-root"
+                        >
+                          Teams can share focus sessions, mood journeys, and curated playlists while keeping individual preferences private.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="reveal reveal-delay-3 MuiBox-root css-0 is-visible"
+            data-reveal="true"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiAccordion-root MuiAccordion-rounded MuiAccordion-gutters css-z9q64i-MuiPaper-root-MuiAccordion-root"
+              style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+            >
+              <h3
+                class="MuiAccordion-heading css-cy7rkm-MuiAccordion-heading"
+              >
+                <button
+                  aria-expanded="false"
+                  class="MuiButtonBase-root MuiAccordionSummary-root MuiAccordionSummary-gutters css-1k1cj3j-MuiButtonBase-root-MuiAccordionSummary-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiAccordionSummary-content MuiAccordionSummary-contentGutters css-yfrx4k-MuiAccordionSummary-content"
+                  >
+                    <h6
+                      class="MuiTypography-root MuiTypography-subtitle1 css-1tcqmck-MuiTypography-root"
+                    >
+                      What makes Moodify different?
+                    </h6>
+                  </span>
+                  <span
+                    class="MuiAccordionSummary-expandIconWrapper css-1wqf3nl-MuiAccordionSummary-expandIconWrapper"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                      data-testid="ExpandMoreIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </h3>
+              <div
+                class="MuiCollapse-root MuiCollapse-vertical MuiCollapse-hidden css-cwrbtg-MuiCollapse-root"
+                style="min-height: 0px;"
+              >
+                <div
+                  class="MuiCollapse-wrapper MuiCollapse-vertical css-1x6hinx-MuiCollapse-wrapper"
+                >
+                  <div
+                    class="MuiCollapse-wrapperInner MuiCollapse-vertical css-1i4ywhz-MuiCollapse-wrapperInner"
+                  >
+                    <div
+                      class="MuiAccordion-region"
+                      role="region"
+                    >
+                      <div
+                        class="MuiAccordionDetails-root css-1f6346d-MuiAccordionDetails-root"
+                      >
+                        <p
+                          class="MuiTypography-root MuiTypography-body2 css-1m7lbti-MuiTypography-root"
+                        >
+                          Moodify is built for emotional clarity with universal design principles, making it easy, inclusive, and personalized for every listener.
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-lsd0kq"
+    >
+      <div
+        class="MuiContainer-root MuiContainer-maxWidthMd css-168saze-MuiContainer-root"
+      >
+        <h4
+          class="MuiTypography-root MuiTypography-h4 reveal reveal-delay-1 css-1ioejim-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Start building your emotional soundtrack today
+        </h4>
+        <p
+          class="MuiTypography-root MuiTypography-body1 reveal reveal-delay-2 css-g8hail-MuiTypography-root is-visible"
+          data-reveal="true"
+        >
+          Join Moodify and create playlists that evolve with every feeling. Bring focus to work, calm to your routines, and energy when you need it most.
+        </p>
+        <div
+          class="MuiStack-root reveal reveal-delay-3 css-67e3wp-MuiStack-root is-visible"
+          data-reveal="true"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary css-buxtrm-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Create your account
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeMedium MuiButton-outlinedSizeMedium MuiButton-colorPrimary css-8na1mj-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            Talk to us
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/__tests__/snapshots/__snapshots__/NotFoundPage.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/NotFoundPage.snapshot.test.jsx.snap
@@ -1,0 +1,75 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NotFoundPage snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-p04ei4"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiBox-root css-h1euri"
+    />
+    <div
+      class="fade-in MuiBox-root css-1d46qeb"
+    >
+      <div
+        class="pulse-animation MuiBox-root css-1yorsq6"
+      >
+        <svg
+          aria-hidden="true"
+          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-kxdlsu-MuiSvgIcon-root"
+          data-testid="PriorityHighRoundedIcon"
+          focusable="false"
+          viewBox="0 0 24 24"
+        >
+          <circle
+            cx="12"
+            cy="19"
+            r="2"
+          />
+          <path
+            d="M12 3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2s2-.9 2-2V5c0-1.1-.9-2-2-2"
+          />
+        </svg>
+      </div>
+      <div
+        class="MuiTypography-root MuiTypography-body1 css-57p1yi-MuiTypography-root"
+      >
+        404
+      </div>
+      <h1
+        class="MuiTypography-root MuiTypography-body1 css-1grsb4r-MuiTypography-root"
+      >
+        Page Not Found
+      </h1>
+      <p
+        class="MuiTypography-root MuiTypography-body1 css-12hq1en-MuiTypography-root"
+      >
+        Oops! The page you are looking for does not exist or has been moved.
+      </p>
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-w3t29f-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+            data-testid="HomeRoundedIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 19v-5h4v5c0 .55.45 1 1 1h3c.55 0 1-.45 1-1v-7h1.7c.46 0 .68-.57.33-.87L12.67 3.6c-.38-.34-.96-.34-1.34 0l-8.36 7.53c-.34.3-.13.87.33.87H5v7c0 .55.45 1 1 1h3c.55 0 1-.45 1-1"
+            />
+          </svg>
+        </span>
+        Go Back Home
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/__tests__/snapshots/__snapshots__/PasskeysPage.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/PasskeysPage.snapshot.test.jsx.snap
@@ -1,0 +1,213 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PasskeysPage snapshot matches the rendered markup once the passkey list loads 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-9yqx9l"
+  >
+    <div
+      class="MuiBox-root css-hnd82n"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation6 css-81h786-MuiPaper-root"
+        style="--Paper-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);"
+      >
+        <div
+          class="MuiBox-root css-nn8g05"
+        />
+        <div
+          class="MuiBox-root css-1uzdoqd"
+        />
+        <div
+          class="MuiBox-root css-m0h6qr"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1du5w5j-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18yka4h-MuiSvgIcon-root"
+                data-testid="ArrowBackIosNewIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M17.77 3.77 16 2 6 12l10 10 1.77-1.77L9.54 12z"
+                />
+              </svg>
+            </span>
+            Profile
+          </button>
+        </div>
+        <div
+          class="MuiBox-root css-1skl395"
+        >
+          <div
+            class="MuiBox-root css-12utg5j"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-125t280-MuiSvgIcon-root"
+              data-testid="FingerprintIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17.81 4.47c-.08 0-.16-.02-.23-.06C15.66 3.42 14 3 12.01 3c-1.98 0-3.86.47-5.57 1.41-.24.13-.54.04-.68-.2-.13-.24-.04-.55.2-.68C7.82 2.52 9.86 2 12.01 2c2.13 0 3.99.47 6.03 1.52.25.13.34.43.21.67-.09.18-.26.28-.44.28M3.5 9.72c-.1 0-.2-.03-.29-.09-.23-.16-.28-.47-.12-.7.99-1.4 2.25-2.5 3.75-3.27C9.98 4.04 14 4.03 17.15 5.65c1.5.77 2.76 1.86 3.75 3.25.16.22.11.54-.12.7s-.54.11-.7-.12c-.9-1.26-2.04-2.25-3.39-2.94-2.87-1.47-6.54-1.47-9.4.01-1.36.7-2.5 1.7-3.4 2.96-.08.14-.23.21-.39.21m6.25 12.07c-.13 0-.26-.05-.35-.15-.87-.87-1.34-1.43-2.01-2.64-.69-1.23-1.05-2.73-1.05-4.34 0-2.97 2.54-5.39 5.66-5.39s5.66 2.42 5.66 5.39c0 .28-.22.5-.5.5s-.5-.22-.5-.5c0-2.42-2.09-4.39-4.66-4.39s-4.66 1.97-4.66 4.39c0 1.44.32 2.77.93 3.85.64 1.15 1.08 1.64 1.85 2.42.19.2.19.51 0 .71-.11.1-.24.15-.37.15m7.17-1.85c-1.19 0-2.24-.3-3.1-.89-1.49-1.01-2.38-2.65-2.38-4.39 0-.28.22-.5.5-.5s.5.22.5.5c0 1.41.72 2.74 1.94 3.56.71.48 1.54.71 2.54.71.24 0 .64-.03 1.04-.1.27-.05.53.13.58.41.05.27-.13.53-.41.58-.57.11-1.07.12-1.21.12M14.91 22c-.04 0-.09-.01-.13-.02-1.59-.44-2.63-1.03-3.72-2.1-1.4-1.39-2.17-3.24-2.17-5.22 0-1.62 1.38-2.94 3.08-2.94s3.08 1.32 3.08 2.94c0 1.07.93 1.94 2.08 1.94s2.08-.87 2.08-1.94c0-3.77-3.25-6.83-7.25-6.83-2.84 0-5.44 1.58-6.61 4.03-.39.81-.59 1.76-.59 2.8 0 .78.07 2.01.67 3.61.1.26-.03.55-.29.64-.26.1-.55-.04-.64-.29-.49-1.31-.73-2.61-.73-3.96 0-1.2.23-2.29.68-3.24 1.33-2.79 4.28-4.6 7.51-4.6 4.55 0 8.25 3.51 8.25 7.83 0 1.62-1.38 2.94-3.08 2.94s-3.08-1.32-3.08-2.94c0-1.07-.93-1.94-2.08-1.94s-2.08.87-2.08 1.94c0 1.71.66 3.31 1.87 4.51.95.94 1.86 1.46 3.27 1.85.27.07.42.35.35.61-.05.23-.26.38-.47.38"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-1fjtzvx"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-overline css-1m101xo-MuiTypography-root"
+            >
+              Security
+            </span>
+            <h5
+              class="MuiTypography-root MuiTypography-h5 css-1wfw7tb-MuiTypography-root"
+            >
+              Your passkeys
+            </h5>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1jzyj67-MuiTypography-root"
+            >
+              Sign in with Face ID, a fingerprint, or your screen lock — no password required.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1htnnur"
+        >
+          <div
+            class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-fgve35-MuiChip-root"
+          >
+            <span
+              class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+            >
+              0 passkeys
+            </span>
+          </div>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-2pxtij-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                data-testid="AddRoundedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1"
+                />
+              </svg>
+            </span>
+            Add a passkey
+          </button>
+        </div>
+      </div>
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-far3oq-MuiPaper-root"
+        style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+      >
+        <div
+          class="MuiStack-root css-vxo2m1-MuiStack-root"
+        >
+          <div
+            class="MuiBox-root css-1nsip3x"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+              data-testid="KeyRoundedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M20.59 10h-7.94c-.95-2.69-3.76-4.5-6.88-3.88-2.29.46-4.15 2.3-4.63 4.58C.32 14.58 3.26 18 7 18c2.61 0 4.83-1.67 5.65-4H13l1.29 1.29c.39.39 1.02.39 1.41 0L17 14l1.29 1.29c.39.39 1.03.39 1.42 0l2.59-2.61c.39-.39.39-1.03-.01-1.42l-.99-.97c-.2-.19-.45-.29-.71-.29M7 15c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-0"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1e2jq1i-MuiTypography-root"
+            >
+              Registered passkeys
+            </p>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1fntgda-MuiTypography-root"
+            >
+              Each passkey is tied to a device or password manager.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-1vgahxq"
+        >
+          <div
+            class="MuiBox-root css-17b5uzm"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-ktljgz-MuiSvgIcon-root"
+              data-testid="FingerprintIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17.81 4.47c-.08 0-.16-.02-.23-.06C15.66 3.42 14 3 12.01 3c-1.98 0-3.86.47-5.57 1.41-.24.13-.54.04-.68-.2-.13-.24-.04-.55.2-.68C7.82 2.52 9.86 2 12.01 2c2.13 0 3.99.47 6.03 1.52.25.13.34.43.21.67-.09.18-.26.28-.44.28M3.5 9.72c-.1 0-.2-.03-.29-.09-.23-.16-.28-.47-.12-.7.99-1.4 2.25-2.5 3.75-3.27C9.98 4.04 14 4.03 17.15 5.65c1.5.77 2.76 1.86 3.75 3.25.16.22.11.54-.12.7s-.54.11-.7-.12c-.9-1.26-2.04-2.25-3.39-2.94-2.87-1.47-6.54-1.47-9.4.01-1.36.7-2.5 1.7-3.4 2.96-.08.14-.23.21-.39.21m6.25 12.07c-.13 0-.26-.05-.35-.15-.87-.87-1.34-1.43-2.01-2.64-.69-1.23-1.05-2.73-1.05-4.34 0-2.97 2.54-5.39 5.66-5.39s5.66 2.42 5.66 5.39c0 .28-.22.5-.5.5s-.5-.22-.5-.5c0-2.42-2.09-4.39-4.66-4.39s-4.66 1.97-4.66 4.39c0 1.44.32 2.77.93 3.85.64 1.15 1.08 1.64 1.85 2.42.19.2.19.51 0 .71-.11.1-.24.15-.37.15m7.17-1.85c-1.19 0-2.24-.3-3.1-.89-1.49-1.01-2.38-2.65-2.38-4.39 0-.28.22-.5.5-.5s.5.22.5.5c0 1.41.72 2.74 1.94 3.56.71.48 1.54.71 2.54.71.24 0 .64-.03 1.04-.1.27-.05.53.13.58.41.05.27-.13.53-.41.58-.57.11-1.07.12-1.21.12M14.91 22c-.04 0-.09-.01-.13-.02-1.59-.44-2.63-1.03-3.72-2.1-1.4-1.39-2.17-3.24-2.17-5.22 0-1.62 1.38-2.94 3.08-2.94s3.08 1.32 3.08 2.94c0 1.07.93 1.94 2.08 1.94s2.08-.87 2.08-1.94c0-3.77-3.25-6.83-7.25-6.83-2.84 0-5.44 1.58-6.61 4.03-.39.81-.59 1.76-.59 2.8 0 .78.07 2.01.67 3.61.1.26-.03.55-.29.64-.26.1-.55-.04-.64-.29-.49-1.31-.73-2.61-.73-3.96 0-1.2.23-2.29.68-3.24 1.33-2.79 4.28-4.6 7.51-4.6 4.55 0 8.25 3.51 8.25 7.83 0 1.62-1.38 2.94-3.08 2.94s-3.08-1.32-3.08-2.94c0-1.07-.93-1.94-2.08-1.94s-2.08.87-2.08 1.94c0 1.71.66 3.31 1.87 4.51.95.94 1.86 1.46 3.27 1.85.27.07.42.35.35.61-.05.23-.26.38-.47.38"
+              />
+            </svg>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1y5izml-MuiTypography-root"
+          >
+            No passkeys yet
+          </p>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-9fgx8v-MuiTypography-root"
+          >
+            Add a passkey to sign in without typing your password. Your password keeps working too.
+          </p>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1at4kpy-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                data-testid="AddRoundedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M18 13h-5v5c0 .55-.45 1-1 1s-1-.45-1-1v-5H6c-.55 0-1-.45-1-1s.45-1 1-1h5V6c0-.55.45-1 1-1s1 .45 1 1v5h5c.55 0 1 .45 1 1s-.45 1-1 1"
+                />
+              </svg>
+            </span>
+            Add your first passkey
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/__tests__/snapshots/__snapshots__/PrivacyPolicyPage.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/PrivacyPolicyPage.snapshot.test.jsx.snap
@@ -1,0 +1,419 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PrivacyPolicyPage snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-12xscni"
+  >
+    <div
+      class="MuiBox-root css-p1ey8d"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation6 css-sxtdlk-MuiPaper-root"
+        style="--Paper-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);"
+      >
+        <div
+          class="MuiBox-root css-1ofo8nu"
+        />
+        <div
+          class="MuiBox-root css-jy0co"
+        />
+        <div
+          class="MuiStack-root css-1nm05g8-MuiStack-root"
+        >
+          <div
+            class="MuiBox-root css-nqbrid"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-m4bq6r-MuiSvgIcon-root"
+              data-testid="ShieldOutlinedIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 2 4 5v6.09c0 5.05 3.41 9.76 8 10.91 4.59-1.15 8-5.86 8-10.91V5zm6 9.09c0 4-2.55 7.7-6 8.83-3.45-1.13-6-4.82-6-8.83v-4.7l6-2.25 6 2.25z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-overline css-1uh078x-MuiTypography-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1ahupxw-MuiSvgIcon-root"
+                data-testid="PolicyOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 1 3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5zm7 10c0 1.85-.51 3.65-1.38 5.21l-1.45-1.45c1.29-1.94 1.07-4.58-.64-6.29-1.95-1.95-5.12-1.95-7.07 0s-1.95 5.12 0 7.07c1.71 1.71 4.35 1.92 6.29.64l1.72 1.72c-1.19 1.42-2.73 2.51-4.47 3.04-4.02-1.25-7-5.42-7-9.94V6.3l7-3.11 7 3.11zm-7 4c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3"
+                />
+              </svg>
+              Legal · Privacy
+            </span>
+            <h1
+              class="MuiTypography-root MuiTypography-h3 css-5i1p05-MuiTypography-root"
+            >
+              Privacy Policy
+            </h1>
+            <div
+              class="MuiStack-root css-1cy7lme-MuiStack-root"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1lhanss-MuiChip-root"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-18yka4h-MuiSvgIcon-root"
+                  data-testid="ScheduleIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8"
+                  />
+                  <path
+                    d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                  />
+                </svg>
+                <span
+                  class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                >
+                  Last updated: June 15, 2024
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-1pmq41s-MuiTypography-root"
+        >
+          At Moodify, we value your privacy and are committed to protecting your personal information. This policy explains how we collect, use, and safeguard your data when you use our application.
+        </p>
+      </div>
+      <div
+        class="MuiBox-root css-yd8sa2"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              01
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Data Collection
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              We collect the following types of information:
+            </p>
+            <ul>
+              <li>
+                <strong>
+                  Personal Information:
+                </strong>
+                 Username, email address, and (hashed) password - only what's required to create and protect your account.
+              </li>
+              <li>
+                <strong>
+                  Mood & Listening History:
+                </strong>
+                 The moods you analyze, recommendations you save, and tracks you open. Used to personalize future recommendations on your account only.
+              </li>
+              <li>
+                <strong>
+                  Inference Inputs:
+                </strong>
+                 Text snippets, voice clips, or photos you submit for mood detection. Processed in-memory by our inference service and 
+                <strong>
+                  not retained
+                </strong>
+                 after the response is built.
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              02
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              How We Use Your Data
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <ul>
+              <li>
+                To authenticate you and keep your account secure.
+              </li>
+              <li>
+                To personalize your mood-based recommendations via a small on-the-fly recency-weighted model that runs per request.
+              </li>
+              <li>
+                To diagnose problems and improve the service in aggregate - we never inspect individual accounts unless required by law.
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              03
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Where Your Data Lives
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              Your account and history are stored in a managed MongoDB Atlas cluster. The Django API runs on Vercel; the ML inference service runs on Modal. Each request to the recommender hits Deezer's free, keyless Search API for the track list; no listening data is shared with third parties.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              04
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Cookies &amp; Local Storage
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              We use 
+              <strong>
+                localStorage
+              </strong>
+               in your browser to keep your JWT access + refresh tokens so you stay signed in across tabs. We do 
+              <strong>
+                not
+              </strong>
+               use third-party analytics or advertising cookies.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              05
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Your Choices
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <ul>
+              <li>
+                <strong>
+                  View your data:
+                </strong>
+                 Your Profile page shows everything we have for you.
+              </li>
+              <li>
+                <strong>
+                  Clear individual histories:
+                </strong>
+                 Mood, listening and saved-recommendations histories each have a one-tap "Clear all" action.
+              </li>
+              <li>
+                <strong>
+                  Delete your account:
+                </strong>
+                 Settings → "Delete account" permanently removes your account and every record tied to it.
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              06
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Security
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              Passwords are stored using PBKDF2 hashing - never in plain text. All traffic is TLS-encrypted in transit. Auth uses short-lived JWT access tokens with silent refresh; tokens live only in your browser's localStorage.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              07
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Children's Privacy
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              Moodify is not directed at children under 13. We do not knowingly collect personal information from anyone under 13.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              08
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Changes to this Policy
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              We may update this policy from time to time. Material changes will be announced in the app and reflected here with a new "Last updated" date.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              09
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Contact
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              Questions, concerns, or data-removal requests: 
+              <a
+                href="mailto:hoangson091104@gmail.com"
+              >
+                hoangson091104@gmail.com
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1bl76u5-MuiPaper-root"
+        style="--Paper-shadow: none;"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-vzgp1-MuiTypography-root"
+        >
+          Questions about this policy? Reach out at 
+          <a
+            class="MuiBox-root css-1feb05w"
+            href="mailto:hoangson091104@gmail.com"
+          >
+            hoangson091104@gmail.com
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/__tests__/snapshots/__snapshots__/ProfilePage.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/ProfilePage.snapshot.test.jsx.snap
@@ -1,0 +1,854 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ProfilePage snapshot matches the rendered markup once the profile loads 1`] = `
+<DocumentFragment>
+  <div
+    style="padding: 0px; font-family: Poppins;"
+  >
+    <div
+      class="MuiBox-root css-9yqx9l"
+    >
+      <div
+        class="MuiBox-root css-so5mn8"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation6 css-sxtdlk-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiBox-root css-1ofo8nu"
+          />
+          <div
+            class="MuiBox-root css-jy0co"
+          />
+          <div
+            class="MuiBox-root css-1skl395"
+          >
+            <div
+              class="MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault css-9temqf-MuiAvatar-root"
+            >
+              T
+            </div>
+            <div
+              class="MuiBox-root css-1fjtzvx"
+            >
+              <span
+                class="MuiTypography-root MuiTypography-overline css-1m101xo-MuiTypography-root"
+              >
+                Your profile
+              </span>
+              <h5
+                class="MuiTypography-root MuiTypography-h5 css-1wfw7tb-MuiTypography-root"
+              >
+                Welcome, testuser!
+              </h5>
+              <p
+                class="MuiTypography-root MuiTypography-body1 css-59vmsd-MuiTypography-root"
+              >
+                Your moods, your music, your history - all in one place.
+              </p>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-z3u1o7"
+          >
+            <div
+              class="MuiBox-root css-194ztwn"
+            >
+              <div
+                class="MuiBox-root css-14swv7n"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="MoodOutlinedIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8m3.5-9c.83 0 1.5-.67 1.5-1.5S16.33 8 15.5 8 14 8.67 14 9.5s.67 1.5 1.5 1.5m-7 0c.83 0 1.5-.67 1.5-1.5S9.33 8 8.5 8 7 8.67 7 9.5 7.67 11 8.5 11m3.5 6.5c2.33 0 4.31-1.46 5.11-3.5H6.89c.8 2.04 2.78 3.5 5.11 3.5"
+                  />
+                </svg>
+              </div>
+              <div
+                class="MuiBox-root css-1xhmi63"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-gtjzv8-MuiTypography-root"
+                >
+                  2
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-f9z5ed-MuiTypography-root"
+                >
+                  Moods logged
+                </p>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-194ztwn"
+            >
+              <div
+                class="MuiBox-root css-1jm9qu8"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="LibraryMusicIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m-2 5h-3v5.5c0 1.38-1.12 2.5-2.5 2.5S10 13.88 10 12.5s1.12-2.5 2.5-2.5c.57 0 1.08.19 1.5.51V5h4zM4 6H2v14c0 1.1.9 2 2 2h14v-2H4z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="MuiBox-root css-1xhmi63"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-gtjzv8-MuiTypography-root"
+                >
+                  1
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-f9z5ed-MuiTypography-root"
+                >
+                  Saved tracks
+                </p>
+              </div>
+            </div>
+            <div
+              class="MuiBox-root css-194ztwn"
+            >
+              <div
+                class="MuiBox-root css-t6cy8b"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="HistoryToggleOffIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m15.1 19.37 1 1.74c-.96.44-2.01.73-3.1.84v-2.02c.74-.09 1.44-.28 2.1-.56M4.07 13H2.05c.11 1.1.4 2.14.84 3.1l1.74-1c-.28-.66-.47-1.36-.56-2.1M15.1 4.63l1-1.74c-.96-.44-2-.73-3.1-.84v2.02c.74.09 1.44.28 2.1.56M19.93 11h2.02c-.11-1.1-.4-2.14-.84-3.1l-1.74 1c.28.66.47 1.36.56 2.1M8.9 19.37l-1 1.74c.96.44 2.01.73 3.1.84v-2.02c-.74-.09-1.44-.28-2.1-.56M11 4.07V2.05c-1.1.11-2.14.4-3.1.84l1 1.74c.66-.28 1.36-.47 2.1-.56m7.36 3.1 1.74-1.01c-.63-.87-1.4-1.64-2.27-2.27l-1.01 1.74c.59.45 1.1.96 1.54 1.54M4.63 8.9l-1.74-1c-.44.96-.73 2-.84 3.1h2.02c.09-.74.28-1.44.56-2.1m15.3 4.1c-.09.74-.28 1.44-.56 2.1l1.74 1c.44-.96.73-2.01.84-3.1zm-3.1 5.36 1.01 1.74c.87-.63 1.64-1.4 2.27-2.27l-1.74-1.01c-.45.59-.96 1.1-1.54 1.54M7.17 5.64l-1-1.75c-.88.64-1.64 1.4-2.27 2.28l1.74 1.01c.44-.59.95-1.1 1.53-1.54M5.64 16.83l-1.74 1c.63.87 1.4 1.64 2.27 2.27l1.01-1.74c-.59-.44-1.1-.95-1.54-1.53M13 7h-2v5.41l4.29 4.29 1.41-1.41-3.7-3.7z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="MuiBox-root css-1xhmi63"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-gtjzv8-MuiTypography-root"
+                >
+                  0
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-f9z5ed-MuiTypography-root"
+                >
+                  Listened
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-far3oq-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-vxo2m1-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-wu5alo"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                data-testid="MoodOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8m3.5-9c.83 0 1.5-.67 1.5-1.5S16.33 8 15.5 8 14 8.67 14 9.5s.67 1.5 1.5 1.5m-7 0c.83 0 1.5-.67 1.5-1.5S9.33 8 8.5 8 7 8.67 7 9.5 7.67 11 8.5 11m3.5 6.5c2.33 0 4.31-1.46 5.11-3.5H6.89c.8 2.04 2.78 3.5 5.11 3.5"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiStack-root css-1u5acgj-MuiStack-root"
+            >
+              <div
+                class="MuiBox-root css-0"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-1e2jq1i-MuiTypography-root"
+                >
+                  Your mood history
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-1531mqi-MuiTypography-root"
+                >
+                  Tap any mood to remix recommendations from it.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-1ofrux8"
+          >
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1dfov5y-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-d8i980-MuiButton-startIcon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="PlaylistRemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M14 10H3v2h11zm0-4H3v2h11zM3 16h7v-2H3zm11.41 6L17 19.41 19.59 22 21 20.59 18.41 18 21 15.41 19.59 14 17 16.59 14.41 14 13 15.41 15.59 18 13 20.59z"
+                  />
+                </svg>
+              </span>
+              Clear all
+            </button>
+          </div>
+          <div
+            class="MuiBox-root css-zefc5s"
+          >
+            <div
+              class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault css-1vnpmml-MuiButtonBase-root-MuiChip-root"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+              >
+                <span
+                  style="display: inline-flex; align-items: center; gap: 6px;"
+                >
+                  <span
+                    aria-hidden="true"
+                  >
+                    😢
+                  </span>
+                  <span>
+                    Sad
+                  </span>
+                </span>
+              </span>
+            </div>
+            <div
+              class="MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault css-1vnpmml-MuiButtonBase-root-MuiChip-root"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+              >
+                <span
+                  style="display: inline-flex; align-items: center; gap: 6px;"
+                >
+                  <span
+                    aria-hidden="true"
+                  >
+                    😊
+                  </span>
+                  <span>
+                    Happy
+                  </span>
+                </span>
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-far3oq-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-vxo2m1-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-wu5alo"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                data-testid="LibraryMusicIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M20 2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m-2 5h-3v5.5c0 1.38-1.12 2.5-2.5 2.5S10 13.88 10 12.5s1.12-2.5 2.5-2.5c.57 0 1.08.19 1.5.51V5h4zM4 6H2v14c0 1.1.9 2 2 2h14v-2H4z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiStack-root css-1u5acgj-MuiStack-root"
+            >
+              <div
+                class="MuiBox-root css-0"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-1e2jq1i-MuiTypography-root"
+                >
+                  Your saved recommendations
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-1531mqi-MuiTypography-root"
+                >
+                  Tracks you got after analyzing a mood.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-1ofrux8"
+          >
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1dfov5y-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-d8i980-MuiButton-startIcon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="PlaylistRemoveIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M14 10H3v2h11zm0-4H3v2h11zM3 16h7v-2H3zm11.41 6L17 19.41 19.59 22 21 20.59 18.41 18 21 15.41 19.59 14 17 16.59 14.41 14 13 15.41 15.59 18 13 20.59z"
+                  />
+                </svg>
+              </span>
+              Clear all
+            </button>
+          </div>
+          <div
+            class="MuiStack-root css-1367e45-MuiStack-root"
+          >
+            <div
+              class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1wdii42-MuiFormControl-root-MuiTextField-root"
+            >
+              <div
+                class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-ot336b-MuiInputBase-root-MuiOutlinedInput-root"
+              >
+                <div
+                  class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1nowbqt-MuiInputAdornment-root"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="notranslate"
+                  >
+                    ​
+                  </span>
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-5n28uf-MuiSvgIcon-root"
+                    data-testid="SearchIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                    />
+                  </svg>
+                </div>
+                <input
+                  aria-invalid="false"
+                  class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
+                  id=":r6:"
+                  placeholder="Search saved tracks…"
+                  type="text"
+                  value=""
+                />
+                <fieldset
+                  aria-hidden="true"
+                  class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+                >
+                  <legend
+                    class="css-1nf2c5d-MuiNotchedOutlined-root"
+                  >
+                    <span
+                      aria-hidden="true"
+                      class="notranslate"
+                    >
+                      ​
+                    </span>
+                  </legend>
+                </fieldset>
+              </div>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1wgmpx9-MuiButtonBase-root-MuiButton-root"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                  data-testid="SortIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 18h6v-2H3zM3 6v2h18V6zm0 7h12v-2H3z"
+                  />
+                </svg>
+              </span>
+              Recommended
+            </button>
+          </div>
+          <div
+            class="MuiStack-root css-10kbc59-MuiStack-root"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1tysxq0-MuiPaper-root"
+              style="--Paper-shadow: none;"
+            >
+              <div
+                class="MuiBox-root css-ruapjk"
+              >
+                <img
+                  alt=""
+                  class="MuiBox-root css-1ezzyga"
+                  src="img.jpg"
+                />
+              </div>
+              <div
+                class="MuiBox-root css-1fjtzvx"
+              >
+                <div
+                  class="MuiStack-root css-1crizmf-MuiStack-root"
+                >
+                  <div
+                    class="MuiBox-root css-1xhmi63"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-1q9sdi1-MuiTypography-root"
+                      title="Song X"
+                    >
+                      Song X
+                    </p>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 MuiTypography-noWrap css-167cnc-MuiTypography-root"
+                      title="Artist X"
+                    >
+                      Artist X
+                    </p>
+                  </div>
+                  <a
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-pm6a6e-MuiButtonBase-root-MuiButton-root"
+                    href="https://spotify.com/x"
+                    rel="noreferrer"
+                    tabindex="0"
+                    target="_blank"
+                  >
+                    <span
+                      class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18yka4h-MuiSvgIcon-root"
+                        data-testid="OpenInNewIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+                        />
+                      </svg>
+                    </span>
+                    Open in Deezer
+                  </a>
+                </div>
+                <div
+                  class="MuiStack-root css-842fkd-MuiStack-root"
+                >
+                  <button
+                    aria-label="Play preview"
+                    class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeMedium css-1o3o526-MuiButtonBase-root-MuiIconButton-root"
+                    disabled=""
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                      data-testid="PlayArrowIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M8 5v14l11-7z"
+                      />
+                    </svg>
+                  </button>
+                  <div
+                    class="MuiBox-root css-1fjtzvx"
+                  >
+                    <span
+                      class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeMedium css-1a5l3n6-MuiSlider-root"
+                    >
+                      <span
+                        class="MuiSlider-rail css-r64h58-MuiSlider-rail"
+                      />
+                      <span
+                        class="MuiSlider-track css-xvk2i-MuiSlider-track"
+                        style="left: 0%; width: 0%;"
+                      />
+                      <span
+                        class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-1xcmt9q-MuiSlider-thumb"
+                        data-index="0"
+                        style="left: 0%;"
+                      >
+                        <input
+                          aria-label="Track position"
+                          aria-orientation="horizontal"
+                          aria-valuemax="30"
+                          aria-valuemin="0"
+                          aria-valuenow="0"
+                          data-index="0"
+                          max="30"
+                          min="0"
+                          step="0.1"
+                          style="border: 0px; height: 100%; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 100%; direction: ltr;"
+                          type="range"
+                          value="0"
+                        />
+                      </span>
+                    </span>
+                    <div
+                      class="MuiStack-root css-1reqwst-MuiStack-root"
+                    >
+                      <p
+                        class="MuiTypography-root MuiTypography-body1 css-1yvpcae-MuiTypography-root"
+                      >
+                        0:00
+                      </p>
+                      <div
+                        class="MuiStack-root css-1k60byz-MuiStack-root"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1k1l0w1-MuiSvgIcon-root"
+                          data-testid="VolumeUpIcon"
+                          focusable="false"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M3 9v6h4l5 5V4L7 9zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02M14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77"
+                          />
+                        </svg>
+                        <p
+                          class="MuiTypography-root MuiTypography-body1 css-1yvpcae-MuiTypography-root"
+                        >
+                          0:30
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-13i121l-MuiTypography-root"
+          >
+            Showing 1 of 1
+          </p>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-far3oq-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-vxo2m1-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-wu5alo"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                data-testid="HistoryToggleOffIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15.1 19.37 1 1.74c-.96.44-2.01.73-3.1.84v-2.02c.74-.09 1.44-.28 2.1-.56M4.07 13H2.05c.11 1.1.4 2.14.84 3.1l1.74-1c-.28-.66-.47-1.36-.56-2.1M15.1 4.63l1-1.74c-.96-.44-2-.73-3.1-.84v2.02c.74.09 1.44.28 2.1.56M19.93 11h2.02c-.11-1.1-.4-2.14-.84-3.1l-1.74 1c.28.66.47 1.36.56 2.1M8.9 19.37l-1 1.74c.96.44 2.01.73 3.1.84v-2.02c-.74-.09-1.44-.28-2.1-.56M11 4.07V2.05c-1.1.11-2.14.4-3.1.84l1 1.74c.66-.28 1.36-.47 2.1-.56m7.36 3.1 1.74-1.01c-.63-.87-1.4-1.64-2.27-2.27l-1.01 1.74c.59.45 1.1.96 1.54 1.54M4.63 8.9l-1.74-1c-.44.96-.73 2-.84 3.1h2.02c.09-.74.28-1.44.56-2.1m15.3 4.1c-.09.74-.28 1.44-.56 2.1l1.74 1c.44-.96.73-2.01.84-3.1zm-3.1 5.36 1.01 1.74c.87-.63 1.64-1.4 2.27-2.27l-1.74-1.01c-.45.59-.96 1.1-1.54 1.54M7.17 5.64l-1-1.75c-.88.64-1.64 1.4-2.27 2.28l1.74 1.01c.44-.59.95-1.1 1.53-1.54M5.64 16.83l-1.74 1c.63.87 1.4 1.64 2.27 2.27l1.01-1.74c-.59-.44-1.1-.95-1.54-1.53M13 7h-2v5.41l4.29 4.29 1.41-1.41-3.7-3.7z"
+                />
+              </svg>
+            </div>
+            <div
+              class="MuiStack-root css-1u5acgj-MuiStack-root"
+            >
+              <div
+                class="MuiBox-root css-0"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-1e2jq1i-MuiTypography-root"
+                >
+                  Tracks you've opened
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-1531mqi-MuiTypography-root"
+                >
+                  Stored as plain strings, freshest at the bottom.
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-1vz9m4w"
+          >
+            <div
+              class="MuiBox-root css-17b5uzm"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1pbxnsj-MuiSvgIcon-root"
+                data-testid="HistoryToggleOffIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="m15.1 19.37 1 1.74c-.96.44-2.01.73-3.1.84v-2.02c.74-.09 1.44-.28 2.1-.56M4.07 13H2.05c.11 1.1.4 2.14.84 3.1l1.74-1c-.28-.66-.47-1.36-.56-2.1M15.1 4.63l1-1.74c-.96-.44-2-.73-3.1-.84v2.02c.74.09 1.44.28 2.1.56M19.93 11h2.02c-.11-1.1-.4-2.14-.84-3.1l-1.74 1c.28.66.47 1.36.56 2.1M8.9 19.37l-1 1.74c.96.44 2.01.73 3.1.84v-2.02c-.74-.09-1.44-.28-2.1-.56M11 4.07V2.05c-1.1.11-2.14.4-3.1.84l1 1.74c.66-.28 1.36-.47 2.1-.56m7.36 3.1 1.74-1.01c-.63-.87-1.4-1.64-2.27-2.27l-1.01 1.74c.59.45 1.1.96 1.54 1.54M4.63 8.9l-1.74-1c-.44.96-.73 2-.84 3.1h2.02c.09-.74.28-1.44.56-2.1m15.3 4.1c-.09.74-.28 1.44-.56 2.1l1.74 1c.44-.96.73-2.01.84-3.1zm-3.1 5.36 1.01 1.74c.87-.63 1.64-1.4 2.27-2.27l-1.74-1.01c-.45.59-.96 1.1-1.54 1.54M7.17 5.64l-1-1.75c-.88.64-1.64 1.4-2.27 2.28l1.74 1.01c.44-.59.95-1.1 1.53-1.54M5.64 16.83l-1.74 1c.63.87 1.4 1.64 2.27 2.27l1.01-1.74c-.59-.44-1.1-.95-1.54-1.53M13 7h-2v5.41l4.29 4.29 1.41-1.41-3.7-3.7z"
+                />
+              </svg>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-s2dg2c-MuiTypography-root"
+            >
+              Nothing here yet
+            </p>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-ym2ag4-MuiTypography-root"
+            >
+              Open a track from your Results page and we'll log it.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-far3oq-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-vxo2m1-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-wu5alo"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                data-testid="SettingsIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19.14 12.94c.04-.3.06-.61.06-.94 0-.32-.02-.64-.07-.94l2.03-1.58c.18-.14.23-.41.12-.61l-1.92-3.32c-.12-.22-.37-.29-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54c-.04-.24-.24-.41-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96c-.22-.08-.47 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.05.3-.09.63-.09.94s.02.64.07.94l-2.03 1.58c-.18.14-.23.41-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6"
+                />
+              </svg>
+            </div>
+            <h6
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Settings
+            </h6>
+          </div>
+          <div
+            class="MuiStack-root css-10kbc59-MuiStack-root"
+          >
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-af13ts-MuiPaper-root"
+              style="--Paper-shadow: none;"
+            >
+              <div
+                class="MuiBox-root css-1556e10"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="AccountCircleIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2m0 4c1.93 0 3.5 1.57 3.5 3.5S13.93 13 12 13s-3.5-1.57-3.5-3.5S10.07 6 12 6m0 14c-2.03 0-4.43-.82-6.14-2.88C7.55 15.8 9.68 15 12 15s4.45.8 6.14 2.12C16.43 19.18 14.03 20 12 20"
+                  />
+                </svg>
+              </div>
+              <div
+                class="MuiBox-root css-1rr4qq7"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-ytur5i-MuiTypography-root"
+                >
+                  Change username
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-ym2ag4-MuiTypography-root"
+                >
+                  @testuser
+                </p>
+              </div>
+            </div>
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-af13ts-MuiPaper-root"
+              style="--Paper-shadow: none;"
+            >
+              <div
+                class="MuiBox-root css-1556e10"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="EmailIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2m0 4-8 5-8-5V6l8 5 8-5z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="MuiBox-root css-1rr4qq7"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-ytur5i-MuiTypography-root"
+                >
+                  Update email
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-ym2ag4-MuiTypography-root"
+                >
+                  test@example.com
+                </p>
+              </div>
+            </div>
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-af13ts-MuiPaper-root"
+              style="--Paper-shadow: none;"
+            >
+              <div
+                class="MuiBox-root css-1556e10"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="KeyIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M21 10h-8.35C11.83 7.67 9.61 6 7 6c-3.31 0-6 2.69-6 6s2.69 6 6 6c2.61 0 4.83-1.67 5.65-4H13l2 2 2-2 2 2 4-4.04zM7 15c-1.65 0-3-1.35-3-3s1.35-3 3-3 3 1.35 3 3-1.35 3-3 3"
+                  />
+                </svg>
+              </div>
+              <div
+                class="MuiBox-root css-1rr4qq7"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-ytur5i-MuiTypography-root"
+                >
+                  Change password
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-ym2ag4-MuiTypography-root"
+                >
+                  Pick something memorable (8+ chars).
+                </p>
+              </div>
+            </div>
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-af13ts-MuiPaper-root"
+              style="--Paper-shadow: none;"
+            >
+              <div
+                class="MuiBox-root css-1556e10"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="LogoutIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="m17 7-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="MuiBox-root css-1rr4qq7"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-ytur5i-MuiTypography-root"
+                >
+                  Sign out
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-ym2ag4-MuiTypography-root"
+                >
+                  End this session on this device.
+                </p>
+              </div>
+            </div>
+            <div
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-7vlv6r-MuiPaper-root"
+              style="--Paper-shadow: none;"
+            >
+              <div
+                class="MuiBox-root css-1bfvb3x"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="DeleteIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6zM19 4h-3.5l-1-1h-5l-1 1H5v2h14z"
+                  />
+                </svg>
+              </div>
+              <div
+                class="MuiBox-root css-1rr4qq7"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-1tmwmc9-MuiTypography-root"
+                >
+                  Delete account
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-ym2ag4-MuiTypography-root"
+                >
+                  Permanently remove your account + all history.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/__tests__/snapshots/__snapshots__/RecommendationsPage.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/RecommendationsPage.snapshot.test.jsx.snap
@@ -1,0 +1,293 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RecommendationsPage snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-ubu49k"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation6 css-bf5ajv-MuiPaper-root"
+      style="--Paper-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);"
+    >
+      <div
+        class="MuiBox-root css-1ofo8nu"
+      />
+      <div
+        class="MuiBox-root css-jy0co"
+      />
+      <div
+        class="MuiStack-root css-1nm05g8-MuiStack-root"
+      >
+        <div
+          class="MuiBox-root css-nqbrid"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-m4bq6r-MuiSvgIcon-root"
+            data-testid="LibraryMusicIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M20 2H8c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2m-2 5h-3v5.5c0 1.38-1.12 2.5-2.5 2.5S10 13.88 10 12.5s1.12-2.5 2.5-2.5c.57 0 1.08.19 1.5.51V5h4zM4 6H2v14c0 1.1.9 2 2 2h14v-2H4z"
+            />
+          </svg>
+        </div>
+        <div
+          class="MuiBox-root css-0"
+        >
+          <span
+            class="MuiTypography-root MuiTypography-overline css-1uh078x-MuiTypography-root"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1ahupxw-MuiSvgIcon-root"
+              data-testid="AutoAwesomeIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m19 9 1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25z"
+              />
+            </svg>
+            Sample playlist
+          </span>
+          <h1
+            class="MuiTypography-root MuiTypography-h4 css-i2pu9f-MuiTypography-root"
+          >
+            Music Recommendations
+          </h1>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1gl7at6-MuiTypography-root"
+          >
+            Here are some music recommendations based on your mood: a preview of what every Results page looks like once you've analysed a mood.
+          </p>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-18yqtgc"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-1y4j80u-MuiPaper-root"
+        style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+      >
+        <div
+          class="MuiBox-root css-qt4gs9"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-146ixql-MuiSvgIcon-root"
+            data-testid="MusicNoteIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3z"
+            />
+          </svg>
+          <div
+            class="MuiBox-root css-1t4w4pt"
+          >
+            #1
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-k6j81b"
+        >
+          <h3
+            class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+          >
+            Track 1
+          </h3>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-y46tc8-MuiTypography-root"
+          >
+            Artist: Artist 1
+          </p>
+          <audio
+            controls=""
+            style="width: 100%; height: 32px; margin-bottom: 12px;"
+          >
+            <source
+              src="track1.mp3"
+              type="audio/mpeg"
+            />
+            Your browser does not support the audio element.
+          </audio>
+          <a
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1qyf1zk-MuiButtonBase-root-MuiButton-root"
+            href="https://www.deezer.com"
+            rel="noreferrer"
+            tabindex="0"
+            target="_blank"
+          >
+            Listen on Deezer
+            <span
+              class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeMedium css-1gulhci-MuiButton-endIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6dq5bp-MuiSvgIcon-root"
+                data-testid="OpenInNewIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+                />
+              </svg>
+            </span>
+          </a>
+        </div>
+      </div>
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-1y4j80u-MuiPaper-root"
+        style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+      >
+        <div
+          class="MuiBox-root css-qt4gs9"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-146ixql-MuiSvgIcon-root"
+            data-testid="MusicNoteIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3z"
+            />
+          </svg>
+          <div
+            class="MuiBox-root css-1t4w4pt"
+          >
+            #2
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-k6j81b"
+        >
+          <h3
+            class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+          >
+            Track 2
+          </h3>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-y46tc8-MuiTypography-root"
+          >
+            Artist: Artist 2
+          </p>
+          <audio
+            controls=""
+            style="width: 100%; height: 32px; margin-bottom: 12px;"
+          >
+            <source
+              src="track2.mp3"
+              type="audio/mpeg"
+            />
+            Your browser does not support the audio element.
+          </audio>
+          <a
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1qyf1zk-MuiButtonBase-root-MuiButton-root"
+            href="https://www.deezer.com"
+            rel="noreferrer"
+            tabindex="0"
+            target="_blank"
+          >
+            Listen on Deezer
+            <span
+              class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeMedium css-1gulhci-MuiButton-endIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6dq5bp-MuiSvgIcon-root"
+                data-testid="OpenInNewIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+                />
+              </svg>
+            </span>
+          </a>
+        </div>
+      </div>
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-1y4j80u-MuiPaper-root"
+        style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+      >
+        <div
+          class="MuiBox-root css-qt4gs9"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-146ixql-MuiSvgIcon-root"
+            data-testid="MusicNoteIcon"
+            focusable="false"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3z"
+            />
+          </svg>
+          <div
+            class="MuiBox-root css-1t4w4pt"
+          >
+            #3
+          </div>
+        </div>
+        <div
+          class="MuiBox-root css-k6j81b"
+        >
+          <h3
+            class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+          >
+            Track 3
+          </h3>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-y46tc8-MuiTypography-root"
+          >
+            Artist: Artist 3
+          </p>
+          <audio
+            controls=""
+            style="width: 100%; height: 32px; margin-bottom: 12px;"
+          >
+            <source
+              src="track3.mp3"
+              type="audio/mpeg"
+            />
+            Your browser does not support the audio element.
+          </audio>
+          <a
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-1qyf1zk-MuiButtonBase-root-MuiButton-root"
+            href="https://www.deezer.com"
+            rel="noreferrer"
+            tabindex="0"
+            target="_blank"
+          >
+            Listen on Deezer
+            <span
+              class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeMedium css-1gulhci-MuiButton-endIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6dq5bp-MuiSvgIcon-root"
+                data-testid="OpenInNewIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+                />
+              </svg>
+            </span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/__tests__/snapshots/__snapshots__/ResultsPage.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/ResultsPage.snapshot.test.jsx.snap
@@ -1,0 +1,663 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResultsPage snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-ofz87u"
+  >
+    <div
+      class="MuiBox-root css-tuvbvg"
+    >
+      <div
+        class="MuiBox-root css-1f9ik77"
+      />
+      <div
+        class="MuiBox-root css-6pypb3"
+      >
+        <div
+          class="MuiStack-root css-1irh47u-MuiStack-root"
+        >
+          <button
+            aria-label="Back to home"
+            class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-14njqya-MuiButtonBase-root-MuiIconButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-7ulkrv-MuiSvgIcon-root"
+              data-testid="ArrowBackIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20z"
+              />
+            </svg>
+          </button>
+          <p
+            class="MuiTypography-root MuiTypography-body1 css-1cxm87c-MuiTypography-root"
+          >
+            YOUR VIBE
+          </p>
+        </div>
+        <div
+          class="MuiStack-root css-5n224u-MuiStack-root"
+        >
+          <div
+            class="MuiBox-root css-1osdn5g"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-m5plui-MuiTypography-root"
+            >
+              😊
+            </p>
+          </div>
+          <div
+            class="MuiBox-root css-1bqk722"
+          >
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-238pks-MuiTypography-root"
+            >
+              DETECTED MOOD
+            </p>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-w5uvux-MuiTypography-root"
+            >
+              Happy
+            </p>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-1vhic3o-MuiTypography-root"
+            >
+              2 tracks tuned to how you feel
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-2hxxdx"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1ug28d3-MuiPaper-root"
+        style="--Paper-shadow: none;"
+      >
+        <div
+          class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-1dv0ssh-MuiFormControl-root-MuiTextField-root"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-sizeSmall MuiInputBase-adornedStart css-ot336b-MuiInputBase-root-MuiOutlinedInput-root"
+          >
+            <div
+              class="MuiInputAdornment-root MuiInputAdornment-positionStart MuiInputAdornment-outlined MuiInputAdornment-sizeSmall css-1nowbqt-MuiInputAdornment-root"
+            >
+              <span
+                aria-hidden="true"
+                class="notranslate"
+              >
+                ​
+              </span>
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-5n28uf-MuiSvgIcon-root"
+                data-testid="SearchIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14"
+                />
+              </svg>
+            </div>
+            <input
+              aria-invalid="false"
+              class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall MuiInputBase-inputAdornedStart css-1q55ijt-MuiInputBase-input-MuiOutlinedInput-input"
+              id=":r1:"
+              placeholder="Search track, artist or album…"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+            >
+              <legend
+                class="css-1nf2c5d-MuiNotchedOutlined-root"
+              >
+                <span
+                  aria-hidden="true"
+                  class="notranslate"
+                >
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+        </div>
+        <div
+          class="MuiStack-root css-1loe5z-MuiStack-root"
+        >
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-u5pwnv-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="SortIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M3 18h6v-2H3zM3 6v2h18V6zm0 7h12v-2H3z"
+                />
+              </svg>
+            </span>
+            Recommended
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-u5pwnv-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="LanguageIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2m6.93 6h-2.95c-.32-1.25-.78-2.45-1.38-3.56 1.84.63 3.37 1.91 4.33 3.56M12 4.04c.83 1.2 1.48 2.53 1.91 3.96h-3.82c.43-1.43 1.08-2.76 1.91-3.96M4.26 14C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2s.06 1.34.14 2zm.82 2h2.95c.32 1.25.78 2.45 1.38 3.56-1.84-.63-3.37-1.9-4.33-3.56m2.95-8H5.08c.96-1.66 2.49-2.93 4.33-3.56C8.81 5.55 8.35 6.75 8.03 8M12 19.96c-.83-1.2-1.48-2.53-1.91-3.96h3.82c-.43 1.43-1.08 2.76-1.91 3.96M14.34 14H9.66c-.09-.66-.16-1.32-.16-2s.07-1.35.16-2h4.68c.09.65.16 1.32.16 2s-.07 1.34-.16 2m.25 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95c-.96 1.65-2.49 2.93-4.33 3.56M16.36 14c.08-.66.14-1.32.14-2s-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2z"
+                />
+              </svg>
+            </span>
+            Global
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-u5pwnv-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-120dh41-MuiSvgIcon-root"
+                data-testid="MusicNoteIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 3v10.55c-.59-.34-1.27-.55-2-.55-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4V7h4V3z"
+                />
+              </svg>
+            </span>
+            Mood: Happy
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-u5pwnv-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall css-1k8xu86-MuiSvgIcon-root"
+                data-testid="AllInclusiveIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M18.6 6.62c-1.44 0-2.8.56-3.77 1.53L12 10.66 10.48 12h.01L7.8 14.39c-.64.64-1.49.99-2.4.99-1.87 0-3.39-1.51-3.39-3.38S3.53 8.62 5.4 8.62c.91 0 1.76.35 2.44 1.03l1.13 1 1.51-1.34L9.22 8.2C8.2 7.18 6.84 6.62 5.4 6.62 2.42 6.62 0 9.04 0 12s2.42 5.38 5.4 5.38c1.44 0 2.8-.56 3.77-1.53l2.83-2.5.01.01L13.52 12h-.01l2.69-2.39c.64-.64 1.49-.99 2.4-.99 1.87 0 3.39 1.51 3.39 3.38s-1.52 3.38-3.39 3.38c-.9 0-1.76-.35-2.44-1.03l-1.14-1.01-1.51 1.34 1.27 1.12c1.02 1.01 2.37 1.57 3.82 1.57 2.98 0 5.4-2.41 5.4-5.38s-2.42-5.37-5.4-5.37"
+                />
+              </svg>
+            </span>
+            Any genre
+          </button>
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-s57a5n-MuiButtonBase-root-MuiButton-root"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                data-testid="ShuffleIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M10.59 9.17 5.41 4 4 5.41l5.17 5.17zM14.5 4l2.04 2.04L4 18.59 5.41 20 17.96 7.46 20 9.5V4zm.33 9.41-1.41 1.41 3.13 3.13L14.5 20H20v-5.5l-2.04 2.04z"
+                />
+              </svg>
+            </span>
+            Shuffle
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="MuiBox-root css-d3mczq"
+    >
+      <div
+        class="MuiStack-root css-nidpyb-MuiStack-root"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-q804p5-MuiTypography-root"
+        >
+          2 tracks for you
+        </p>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-4re38s-MuiTypography-root"
+        >
+          Showing 2 of 2
+        </p>
+      </div>
+      <div
+        class="MuiStack-root css-14nepse-MuiStack-root"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-11k9p4t-MuiPaper-root-MuiCard-root"
+          style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiBox-root css-ruapjk"
+          >
+            <div
+              class="MuiAvatar-root MuiAvatar-rounded css-1uva0dw-MuiAvatar-root"
+            >
+              <img
+                alt="Song A"
+                class="MuiAvatar-img css-1su80sj-MuiAvatar-img"
+                src="http://example.com/a.jpg"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-1fjtzvx"
+          >
+            <div
+              class="MuiStack-root css-1crizmf-MuiStack-root"
+            >
+              <div
+                class="MuiBox-root css-1xhmi63"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-x1napj-MuiTypography-root"
+                  title="Song A"
+                >
+                  Song A
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-y3dkch-MuiTypography-root"
+                  title="Artist A"
+                >
+                  Artist A
+                </p>
+              </div>
+              <div
+                class="MuiStack-root css-f6d8rd-MuiStack-root"
+              >
+                <button
+                  aria-label="Like track"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1fryb3n-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-19pfla-MuiSvgIcon-root"
+                    data-testid="ThumbUpOutlinedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M9 21h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.58 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2M9 9l4.34-4.34L12 10h9v2l-3 7H9zM1 9h4v12H1z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Dislike track"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hv6yqn-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-19pfla-MuiSvgIcon-root"
+                    data-testid="ThumbDownOutlinedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2m0 12-4.34 4.34L12 14H3v-2l3-7h9zm4-12h4v12h-4z"
+                    />
+                  </svg>
+                </button>
+                <a
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-y0z7zb-MuiButtonBase-root-MuiButton-root"
+                  href="http://spotify.com/a"
+                  rel="noopener noreferrer"
+                  tabindex="0"
+                  target="_blank"
+                >
+                  <span
+                    class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6dq5bp-MuiSvgIcon-root"
+                      data-testid="HeadphonesOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 3c-4.97 0-9 4.03-9 9v7c0 1.1.9 2 2 2h4v-8H5v-1c0-3.87 3.13-7 7-7s7 3.13 7 7v1h-4v8h4c1.1 0 2-.9 2-2v-7c0-4.97-4.03-9-9-9M7 15v4H5v-4zm12 4h-2v-4h2z"
+                      />
+                    </svg>
+                  </span>
+                  Open in Deezer
+                  <span
+                    class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeMedium css-1gulhci-MuiButton-endIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18yka4h-MuiSvgIcon-root"
+                      data-testid="OpenInNewIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+                      />
+                    </svg>
+                  </span>
+                </a>
+              </div>
+            </div>
+            <div
+              class="MuiStack-root css-12vfs9c-MuiStack-root"
+            >
+              <button
+                aria-label="Play preview"
+                class="MuiButtonBase-root Mui-disabled MuiIconButton-root Mui-disabled MuiIconButton-sizeMedium css-usxmjv-MuiButtonBase-root-MuiIconButton-root"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="PlayArrowIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M8 5v14l11-7z"
+                  />
+                </svg>
+              </button>
+              <div
+                class="MuiBox-root css-1fjtzvx"
+              >
+                <span
+                  class="MuiSlider-root MuiSlider-colorPrimary MuiSlider-sizeMedium css-1lifbyj-MuiSlider-root"
+                >
+                  <span
+                    class="MuiSlider-rail css-r64h58-MuiSlider-rail"
+                  />
+                  <span
+                    class="MuiSlider-track css-xvk2i-MuiSlider-track"
+                    style="left: 0%; width: 0%;"
+                  />
+                  <span
+                    class="MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary MuiSlider-thumb MuiSlider-thumbSizeMedium MuiSlider-thumbColorPrimary css-1xcmt9q-MuiSlider-thumb"
+                    data-index="0"
+                    style="left: 0%;"
+                  >
+                    <input
+                      aria-label="Track position"
+                      aria-orientation="horizontal"
+                      aria-valuemax="30"
+                      aria-valuemin="0"
+                      aria-valuenow="0"
+                      data-index="0"
+                      max="30"
+                      min="0"
+                      step="0.1"
+                      style="border: 0px; height: 100%; margin: -1px; overflow: hidden; padding: 0px; position: absolute; white-space: nowrap; width: 100%; direction: ltr;"
+                      type="range"
+                      value="0"
+                    />
+                  </span>
+                </span>
+                <div
+                  class="MuiStack-root css-1reqwst-MuiStack-root"
+                >
+                  <p
+                    class="MuiTypography-root MuiTypography-body1 css-1yvpcae-MuiTypography-root"
+                  >
+                    0:00
+                  </p>
+                  <div
+                    class="MuiStack-root css-1k60byz-MuiStack-root"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1k1l0w1-MuiSvgIcon-root"
+                      data-testid="VolumeUpIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M3 9v6h4l5 5V4L7 9zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02M14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77"
+                      />
+                    </svg>
+                    <p
+                      class="MuiTypography-root MuiTypography-body1 css-1yvpcae-MuiTypography-root"
+                    >
+                      0:30
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-11k9p4t-MuiPaper-root-MuiCard-root"
+          style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiBox-root css-ruapjk"
+          >
+            <div
+              class="MuiAvatar-root MuiAvatar-rounded css-1uva0dw-MuiAvatar-root"
+            >
+              <img
+                alt="Song B"
+                class="MuiAvatar-img css-1su80sj-MuiAvatar-img"
+                src="http://example.com/b.jpg"
+              />
+            </div>
+          </div>
+          <div
+            class="MuiBox-root css-1fjtzvx"
+          >
+            <div
+              class="MuiStack-root css-1crizmf-MuiStack-root"
+            >
+              <div
+                class="MuiBox-root css-1xhmi63"
+              >
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-x1napj-MuiTypography-root"
+                  title="Song B"
+                >
+                  Song B
+                </p>
+                <p
+                  class="MuiTypography-root MuiTypography-body1 css-y3dkch-MuiTypography-root"
+                  title="Artist B"
+                >
+                  Artist B
+                </p>
+              </div>
+              <div
+                class="MuiStack-root css-f6d8rd-MuiStack-root"
+              >
+                <button
+                  aria-label="Like track"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-1fryb3n-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-19pfla-MuiSvgIcon-root"
+                    data-testid="ThumbUpOutlinedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M9 21h9c.83 0 1.54-.5 1.84-1.22l3.02-7.05c.09-.23.14-.47.14-.73v-2c0-1.1-.9-2-2-2h-6.31l.95-4.57.03-.32c0-.41-.17-.79-.44-1.06L14.17 1 7.58 7.59C7.22 7.95 7 8.45 7 9v10c0 1.1.9 2 2 2M9 9l4.34-4.34L12 10h9v2l-3 7H9zM1 9h4v12H1z"
+                    />
+                  </svg>
+                </button>
+                <button
+                  aria-label="Dislike track"
+                  class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-hv6yqn-MuiButtonBase-root-MuiIconButton-root"
+                  data-mui-internal-clone-element="true"
+                  tabindex="0"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-19pfla-MuiSvgIcon-root"
+                    data-testid="ThumbDownOutlinedIcon"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15 3H6c-.83 0-1.54.5-1.84 1.22l-3.02 7.05c-.09.23-.14.47-.14.73v2c0 1.1.9 2 2 2h6.31l-.95 4.57-.03.32c0 .41.17.79.44 1.06L9.83 23l6.59-6.59c.36-.36.58-.86.58-1.41V5c0-1.1-.9-2-2-2m0 12-4.34 4.34L12 14H3v-2l3-7h9zm4-12h4v12h-4z"
+                    />
+                  </svg>
+                </button>
+                <a
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary css-y0z7zb-MuiButtonBase-root-MuiButton-root"
+                  href="http://spotify.com/b"
+                  rel="noopener noreferrer"
+                  tabindex="0"
+                  target="_blank"
+                >
+                  <span
+                    class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-6dq5bp-MuiSvgIcon-root"
+                      data-testid="HeadphonesOutlinedIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 3c-4.97 0-9 4.03-9 9v7c0 1.1.9 2 2 2h4v-8H5v-1c0-3.87 3.13-7 7-7s7 3.13 7 7v1h-4v8h4c1.1 0 2-.9 2-2v-7c0-4.97-4.03-9-9-9M7 15v4H5v-4zm12 4h-2v-4h2z"
+                      />
+                    </svg>
+                  </span>
+                  Open in Deezer
+                  <span
+                    class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeMedium css-1gulhci-MuiButton-endIcon"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-18yka4h-MuiSvgIcon-root"
+                      data-testid="OpenInNewIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M19 19H5V5h7V3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3z"
+                      />
+                    </svg>
+                  </span>
+                </a>
+              </div>
+            </div>
+            <p
+              class="MuiTypography-root MuiTypography-body1 css-nq5a75-MuiTypography-root"
+            >
+              No preview - open on Deezer to listen
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiStack-root css-1x9wnjl-MuiStack-root"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-1ox1vrp-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+              data-testid="RefreshIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M17.65 6.35C16.2 4.9 14.21 4 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08c-.82 2.33-3.04 4-5.65 4-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4z"
+              />
+            </svg>
+          </span>
+          Shuffle recommendations
+        </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-fullWidth css-fcfcsa-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeMedium css-1sh91j5-MuiButton-startIcon"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+              data-testid="AutoAwesomeIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m19 9 1.25-2.75L23 5l-2.75-1.25L19 1l-1.25 2.75L15 5l2.75 1.25zm-7.5.5L9 4 6.5 9.5 1 12l5.5 2.5L9 20l2.5-5.5L17 12zM19 15l-1.25 2.75L15 19l2.75 1.25L19 23l1.25-2.75L23 19l-2.75-1.25z"
+              />
+            </svg>
+          </span>
+          Analyze another mood
+        </button>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/__tests__/snapshots/__snapshots__/TermsOfServicePage.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/TermsOfServicePage.snapshot.test.jsx.snap
@@ -1,0 +1,455 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TermsOfServicePage snapshot matches the rendered markup 1`] = `
+<DocumentFragment>
+  <div
+    class="MuiBox-root css-12xscni"
+  >
+    <div
+      class="MuiBox-root css-p1ey8d"
+    >
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation6 css-sxtdlk-MuiPaper-root"
+        style="--Paper-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);"
+      >
+        <div
+          class="MuiBox-root css-1ofo8nu"
+        />
+        <div
+          class="MuiBox-root css-jy0co"
+        />
+        <div
+          class="MuiStack-root css-1nm05g8-MuiStack-root"
+        >
+          <div
+            class="MuiBox-root css-nqbrid"
+          >
+            <svg
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-m4bq6r-MuiSvgIcon-root"
+              data-testid="GavelIcon"
+              focusable="false"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="m5.2494 8.0688 2.83-2.8269 14.1343 14.15-2.83 2.8269zm4.2363-4.2415 2.828-2.8289 5.6577 5.656-2.828 2.8289zM.9989 12.3147l2.8284-2.8285 5.6569 5.6569-2.8285 2.8284zM1 21h12v2H1z"
+              />
+            </svg>
+          </div>
+          <div
+            class="MuiBox-root css-0"
+          >
+            <span
+              class="MuiTypography-root MuiTypography-overline css-1uh078x-MuiTypography-root"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1ahupxw-MuiSvgIcon-root"
+                data-testid="PolicyOutlinedIcon"
+                focusable="false"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 1 3 5v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V5zm7 10c0 1.85-.51 3.65-1.38 5.21l-1.45-1.45c1.29-1.94 1.07-4.58-.64-6.29-1.95-1.95-5.12-1.95-7.07 0s-1.95 5.12 0 7.07c1.71 1.71 4.35 1.92 6.29.64l1.72 1.72c-1.19 1.42-2.73 2.51-4.47 3.04-4.02-1.25-7-5.42-7-9.94V6.3l7-3.11 7 3.11zm-7 4c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3"
+                />
+              </svg>
+              Legal · Terms
+            </span>
+            <h1
+              class="MuiTypography-root MuiTypography-h3 css-5i1p05-MuiTypography-root"
+            >
+              Terms of Service
+            </h1>
+            <div
+              class="MuiStack-root css-1cy7lme-MuiStack-root"
+            >
+              <div
+                class="MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-filledDefault css-1lhanss-MuiChip-root"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiChip-icon MuiChip-iconMedium MuiChip-iconColorDefault css-18yka4h-MuiSvgIcon-root"
+                  data-testid="ScheduleIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M11.99 2C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2M12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8"
+                  />
+                  <path
+                    d="M12.5 7H11v6l5.25 3.15.75-1.23-4.5-2.67z"
+                  />
+                </svg>
+                <span
+                  class="MuiChip-label MuiChip-labelMedium css-1dybbl5-MuiChip-label"
+                >
+                  Last updated: June 15, 2024
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-1pmq41s-MuiTypography-root"
+        >
+          Welcome to Moodify. By using our application you agree to these Terms of Service. Please read them carefully - they set out what you can expect from us and what we ask of you.
+        </p>
+      </div>
+      <div
+        class="MuiBox-root css-yd8sa2"
+      >
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              01
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Acceptance of Terms
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              By creating an account or otherwise using Moodify, you agree to be bound by these terms. If you don't agree, please stop using the service.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              02
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Using the Service
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <ul>
+              <li>
+                Be at least 13 years old. Users under 18 should have a parent or guardian's consent.
+              </li>
+              <li>
+                Provide accurate registration information and keep your credentials confidential.
+              </li>
+              <li>
+                Use the service for personal, non-commercial purposes unless we agree in writing otherwise.
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              03
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Acceptable Use
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              You agree 
+              <strong>
+                not
+              </strong>
+               to:
+            </p>
+            <ul>
+              <li>
+                Attempt to bypass authentication, rate limits, or other technical protections.
+              </li>
+              <li>
+                Submit illegal, abusive, or infringing content through any of the mood-detection inputs.
+              </li>
+              <li>
+                Scrape, mirror, or otherwise reuse the service to power a competing product.
+              </li>
+              <li>
+                Probe the inference endpoints with adversarial payloads designed to incur compute cost.
+              </li>
+            </ul>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              04
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Recommendations & Third-Party Services
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              Music recommendations are powered by 
+              <a
+                href="https://deezer.com"
+                rel="noreferrer"
+                target="_blank"
+              >
+                Deezer
+              </a>
+              's free, public Search API. Tapping a track opens it in Deezer's web player. Deezer's own terms apply to playback; Moodify is not responsible for content or availability on that side.
+            </p>
+            <p>
+              Mood detection is performed by self-trained machine-learning models. Results are best-effort and should not be used for medical, psychiatric, or any high-stakes decisions.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              05
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Your Content
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              Text, audio, and image inputs you submit are processed in-memory by our inference service and are 
+              <strong>
+                not retained
+              </strong>
+               after the response is built. The detected mood and the resulting recommendations are stored against your account so the app can personalize over time; you can wipe them at any time from your Profile.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              06
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Service Availability
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              The Django API runs on Vercel and the inference service runs on Modal with scale-to-zero. Cold starts may add up to a couple of seconds to the first request after idle. We don't guarantee an uptime SLA on the free deploy.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              07
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Termination
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              You can delete your account at any time from Profile → Settings → "Delete account". We may suspend or terminate accounts that violate these terms or that abuse the inference endpoints in a way that puts the service at risk.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              08
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Disclaimer of Warranties
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              Moodify is provided "as is" without warranties of any kind. We make no guarantees about the accuracy of mood detection, availability of any specific track, or fitness for a particular purpose.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              09
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Limitation of Liability
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              To the maximum extent permitted by law, Moodify and its maintainer are not liable for any indirect, incidental, consequential, or punitive damages arising out of your use of the service.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              10
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Changes to these Terms
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              We may update these terms occasionally. Continued use after a change constitutes acceptance of the new terms; material changes will be announced in the app.
+            </p>
+          </div>
+        </div>
+        <div
+          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation3 css-raxp3a-MuiPaper-root"
+          style="--Paper-shadow: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);"
+        >
+          <div
+            class="MuiStack-root css-i4mxch-MuiStack-root"
+          >
+            <div
+              class="MuiBox-root css-i3jovp"
+            >
+              11
+            </div>
+            <h2
+              class="MuiTypography-root MuiTypography-h6 css-6usma-MuiTypography-root"
+            >
+              Contact
+            </h2>
+          </div>
+          <div
+            class="MuiBox-root css-2l2e9r"
+          >
+            <p>
+              Questions about these terms? 
+              <a
+                href="mailto:hoangson091104@gmail.com"
+              >
+                hoangson091104@gmail.com
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 css-1bl76u5-MuiPaper-root"
+        style="--Paper-shadow: none;"
+      >
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-vzgp1-MuiTypography-root"
+        >
+          Questions about this agreement? Reach out at 
+          <a
+            class="MuiBox-root css-1feb05w"
+            href="mailto:hoangson091104@gmail.com"
+          >
+            hoangson091104@gmail.com
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
## What

Adds Jest + React Testing Library **snapshot tests for all 10 frontend screens**:

| Screen | Notes |
|--------|-------|
| LandingPage | WebGL `PageBackground` stubbed (jsdom has no WebGL) |
| HomePage | `Date` frozen (time-of-day greeting); waits for loaded profile |
| ProfilePage | axios mocked; waits for loaded profile |
| ResultsPage | `Math.random` pinned so the shuffle order is deterministic |
| RecommendationsPage | static render |
| NotFoundPage | static render |
| ForgotPassword | Toast + router mocked |
| PasskeysPage | `services/passkeys` mocked; waits for list to load |
| PrivacyPolicyPage | `Date` frozen (LegalLayout "last updated" stamp) |
| TermsOfServicePage | `Date` frozen |

Tests live in `frontend/src/__tests__/snapshots/`, one file per screen, each rendering inside the providers it needs (`DarkModeContext`, router, Toast) and asserting `toMatchSnapshot()`. Committed `__snapshots__/*.snap` baselines are included.

## Why deterministic

Every nondeterministic input (WebGL, `Math.random`, `new Date()`, async loading states) is neutralized so the snapshots are stable in CI. Async screens wait for the settled/loaded state rather than capturing the transient loading view.

## Verification

```
Test Suites: 18 passed, 18 total
Tests:       58 passed, 58 total
Snapshots:   10 passed, 10 total
```

Snapshots generated then re-verified with `jest --ci` (matched, not rewritten). No production code changed — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)