### PR TITLE
fix(frontend): render loading overlay above input modals

### DIFF
--- a/frontend/src/styles/styles.css
+++ b/frontend/src/styles/styles.css
@@ -197,20 +197,25 @@ body.light-mode a {
 
 /* Route page transitions: each page slides up into view on arrival and slides
    down out of view on departure (SwitchTransition mode="out-in"). */
-.page-anim {
-  will-change: transform, opacity;
-}
+/* NOTE: `will-change` is applied ONLY during the active transition phases, not
+   on the resting `.page-anim`. A persistent `will-change: transform` creates a
+   stacking context even when no transform is set, which traps position:fixed
+   descendants (e.g. the loading overlay) below MUI modals that portal to
+   <body>. Keeping it scoped to the animating frames lets fixed descendants
+   compete at the document level once the page is at rest. */
 
 .page-enter,
 .page-appear {
   opacity: 0;
   transform: translateY(30px);
+  will-change: transform, opacity;
 }
 
 .page-enter-active,
 .page-appear-active {
   opacity: 1;
   transform: translateY(0);
+  will-change: transform, opacity;
   transition:
     opacity 0.48s ease,
     transform 0.55s cubic-bezier(0.22, 1, 0.36, 1);
@@ -230,6 +235,7 @@ body.light-mode a {
 .page-exit-active {
   opacity: 0;
   transform: translateY(30px);
+  will-change: transform, opacity;
   transition:
     opacity 0.3s ease,
     transform 0.3s ease;


### PR DESCRIPTION
## Problem

When a user opens an input modal (text / voice / face) on the Home page and submits to the backend, the full-screen **loading overlay renders *below* the modal** instead of covering it. The overlay has `position: fixed; z-index: 2000` and the MUI modal default z-index is `1300`, so a naive read says the overlay should win — but it doesn't.

## Root cause — stacking-context trap, not a z-index value

The route wrapper `.page-anim` (wraps every routed page) carried a **persistent** `will-change: transform, opacity`.

`will-change: transform` establishes a **stacking context even when no transform is applied at rest**. That confines every `position: fixed` descendant — including the loading overlay — to `.page-anim`'s body-level stacking level (effectively `z-index: auto` / ~0).

MUI `Modal` portals to `<body>` with `z-index: 1300`. Since `.page-anim`'s context sits at ~0 at the body level, the modal and all its contents paint **above the entire `.page-anim` subtree**, overlay included — no matter that the overlay's internal value is `2000`.

The CSS already had a comment ("No transform at rest so position:fixed descendants behave normally") and zeroed out the resting `transform`, but missed that `will-change` alone is enough to create the trap.

## Fix

Scope `will-change` to only the active `enter` / `appear` / `exit` transition phases instead of the resting `.page-anim`. At rest, `.page-anim` no longer creates a stacking context, so the fixed overlay competes at the document level (`2000 > 1300`) and correctly covers the modal.

- ✅ Overlay now covers the text / voice / face modals during inference.
- ✅ Page-transition animation unchanged — `will-change` perf hint is still present during the frames that actually animate.
- ✅ Root-cause fix: un-traps fixed descendants on **every** route, not just this modal.
- ✅ No JS changes, no z-index escalation, no `!important`.

## Testing

- `npx prettier --write` clean (no diff).
- Manual: open Home → pick a mode → submit → overlay sits on top of the modal and backdrop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)