### PR TITLE
fix(auth): sign in with email + stop cold starts masquerading as bad credentials

### DIFF
--- a/backend/tests/test_auth_endpoints.py
+++ b/backend/tests/test_auth_endpoints.py
@@ -65,6 +65,36 @@ class TestLogin:
         )
         assert resp.status_code == 401
 
+    def test_login_with_email_succeeds(self, api_client, make_user):
+        # Users routinely type their email into the "Username" field; login
+        # accepts either, so the email must work with the right password.
+        make_user(username="bob", password="password123", email="bob@example.com")
+        resp = api_client.post(
+            "/users/login/",
+            {"username": "bob@example.com", "password": "password123"},
+            format="json",
+        )
+        assert resp.status_code == 200
+        assert "access" in resp.data and "refresh" in resp.data
+
+    def test_login_with_email_is_case_insensitive(self, api_client, make_user):
+        make_user(username="bob", password="password123", email="bob@example.com")
+        resp = api_client.post(
+            "/users/login/",
+            {"username": "BOB@Example.com", "password": "password123"},
+            format="json",
+        )
+        assert resp.status_code == 200
+
+    def test_login_with_email_wrong_password_rejected(self, api_client, make_user):
+        make_user(username="bob", password="password123", email="bob@example.com")
+        resp = api_client.post(
+            "/users/login/",
+            {"username": "bob@example.com", "password": "nope"},
+            format="json",
+        )
+        assert resp.status_code == 401
+
     def test_cold_db_returns_503_not_401(self, api_client, make_user):
         # A persistent connection failure must NOT be reported as bad
         # credentials -- it gets its own 503 so the client can retry and the

--- a/backend/tests/test_auth_endpoints.py
+++ b/backend/tests/test_auth_endpoints.py
@@ -1,7 +1,13 @@
 """End-to-end tests for the authentication endpoints (users app)."""
 
+from unittest import mock
+
+import pytest
+from pymongo.errors import PyMongoError
+
 from api.models import UserProfile
 from users.documents import User
+from users import views as users_views
 
 
 class TestRegister:
@@ -58,6 +64,70 @@ class TestLogin:
             "/users/login/", {"username": "ghost", "password": "password123"}, format="json"
         )
         assert resp.status_code == 401
+
+    def test_cold_db_returns_503_not_401(self, api_client, make_user):
+        # A persistent connection failure must NOT be reported as bad
+        # credentials -- it gets its own 503 so the client can retry and the
+        # user isn't told their (correct) password is wrong.
+        make_user(username="bob", password="password123")
+        with mock.patch.object(
+            User, "objects", side_effect=PyMongoError("cold cluster")
+        ):
+            resp = api_client.post(
+                "/users/login/",
+                {"username": "bob", "password": "password123"},
+                format="json",
+            )
+        assert resp.status_code == 503
+
+    def test_cold_db_then_warm_succeeds(self, api_client, make_user):
+        # The first lookup raises (cold connection); the retry succeeds once
+        # the connection is warm, so the user's single sign-in click works.
+        make_user(username="bob", password="password123")
+        real_objects = User.objects
+        calls = {"n": 0}
+
+        def flaky(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise PyMongoError("server selection timed out")
+            return real_objects(*args, **kwargs)
+
+        with mock.patch.object(users_views, "_DB_READ_BACKOFF_SECONDS", 0), \
+                mock.patch.object(User, "objects", side_effect=flaky):
+            resp = api_client.post(
+                "/users/login/",
+                {"username": "bob", "password": "password123"},
+                format="json",
+            )
+        assert resp.status_code == 200
+        assert "access" in resp.data
+        assert calls["n"] == 2  # failed once, retried once, succeeded
+
+
+class TestReadWithRetry:
+    def test_returns_first_success_without_retrying(self):
+        fn = mock.Mock(return_value="ok")
+        assert users_views._read_with_retry(fn, backoff=0) == "ok"
+        assert fn.call_count == 1
+
+    def test_retries_transient_then_succeeds(self):
+        fn = mock.Mock(side_effect=[PyMongoError("a"), PyMongoError("b"), "ok"])
+        assert users_views._read_with_retry(fn, attempts=3, backoff=0) == "ok"
+        assert fn.call_count == 3
+
+    def test_reraises_after_exhausting_attempts(self):
+        fn = mock.Mock(side_effect=PyMongoError("down"))
+        with pytest.raises(PyMongoError):
+            users_views._read_with_retry(fn, attempts=2, backoff=0)
+        assert fn.call_count == 2
+
+    def test_empty_result_is_not_an_error(self):
+        # A query that matches nothing returns None on the first try -- it is
+        # NOT retried (no exception), so a genuine wrong username stays fast.
+        fn = mock.Mock(return_value=None)
+        assert users_views._read_with_retry(fn, backoff=0) is None
+        assert fn.call_count == 1
 
 
 class TestTokenRefresh:

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -375,9 +375,24 @@ def register(request):
 @api_view(["POST"])
 @permission_classes([AllowAny])
 def login(request):
-    """Authenticate a user and return an access/refresh token pair."""
-    username = (request.data.get("username") or "").strip()
+    """Authenticate a user and return an access/refresh token pair.
+
+    The credential field accepts **either** the username or the email
+    address. Users routinely type their email into a field labelled
+    "Username", so matching only on username turned a valid login into a
+    misleading 401. We look up by username first (the primary handle) and
+    fall back to a case-insensitive email match.
+    """
+    identifier = (request.data.get("username") or "").strip()
     password = request.data.get("password") or ""
+
+    def _find_user():
+        user = User.objects(username=identifier).first()
+        # Only attempt the email branch when the input looks like an email,
+        # so a plain username never triggers a needless second query.
+        if user is None and "@" in identifier:
+            user = User.objects(email__iexact=identifier).first()
+        return user
 
     # A cold connection raises here rather than returning a (spurious) None,
     # so retry the lookup before concluding anything about the credentials.
@@ -385,7 +400,7 @@ def login(request):
     # to 503 so the client can retry and the user never sees a cold start
     # disguised as a wrong password.
     try:
-        user = _read_with_retry(lambda: User.objects(username=username).first())
+        user = _read_with_retry(_find_user)
     except PyMongoError:
         logger.error("login: Mongo unavailable after retries", exc_info=True)
         return Response(_DB_WARMING_RESPONSE, status=status.HTTP_503_SERVICE_UNAVAILABLE)

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -6,11 +6,13 @@ Authentication is JWT-only, backed by the mongoengine ``User`` document
 
 import logging
 import re
+import time
 
 import jwt
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from mongoengine.errors import NotUniqueError, ValidationError
+from pymongo.errors import PyMongoError
 from rest_framework import status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -35,6 +37,49 @@ from .tokens import decode_token, issue_tokens
 logger = logging.getLogger(__name__)
 
 MIN_PASSWORD_LENGTH = 8
+
+# How many times to (re)run a Mongo read that hit a transient connection
+# error, and the base back-off between tries. The backend is deployed on a
+# tier that spins down when idle; the *first* query after a wake-up (or
+# after a paused Atlas cluster resumes) can blow the driver's
+# server-selection budget and raise a PyMongoError. A couple of quick
+# retries usually warm the connection within the same request, so the
+# user's first sign-in click succeeds instead of bouncing with a
+# misleading "Invalid credentials" / 500. See `_read_with_retry`.
+_DB_READ_ATTEMPTS = 3
+_DB_READ_BACKOFF_SECONDS = 0.4
+
+
+def _read_with_retry(query_fn, *, attempts=_DB_READ_ATTEMPTS,
+                     backoff=_DB_READ_BACKOFF_SECONDS):
+    """Run a Mongo read callable, retrying only transient connection errors.
+
+    ``query_fn`` is invoked with no arguments and its result returned. A
+    ``PyMongoError`` (server-selection timeout, auto-reconnect, network
+    blip -- all symptoms of a cold connection) triggers a short back-off
+    and another attempt. The final failure is re-raised so the caller can
+    map it to a 503 rather than letting it surface as a 500 or, worse, be
+    misread as bad credentials. A query that simply matches nothing is NOT
+    an error and returns normally on the first try.
+    """
+    last_exc = None
+    for attempt in range(attempts):
+        try:
+            return query_fn()
+        except PyMongoError as exc:  # noqa: PERF203 -- retry loop is the point
+            last_exc = exc
+            logger.warning(
+                "Transient Mongo read failure (attempt %d/%d): %s",
+                attempt + 1, attempts, exc,
+            )
+            if attempt < attempts - 1:
+                time.sleep(backoff * (attempt + 1))
+    raise last_exc
+
+
+_DB_WARMING_RESPONSE = {
+    "error": "Service is waking up. Please try again in a moment.",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -334,7 +379,17 @@ def login(request):
     username = (request.data.get("username") or "").strip()
     password = request.data.get("password") or ""
 
-    user = User.objects(username=username).first()
+    # A cold connection raises here rather than returning a (spurious) None,
+    # so retry the lookup before concluding anything about the credentials.
+    # Only a genuine connection failure reaches the except branch -- map it
+    # to 503 so the client can retry and the user never sees a cold start
+    # disguised as a wrong password.
+    try:
+        user = _read_with_retry(lambda: User.objects(username=username).first())
+    except PyMongoError:
+        logger.error("login: Mongo unavailable after retries", exc_info=True)
+        return Response(_DB_WARMING_RESPONSE, status=status.HTTP_503_SERVICE_UNAVAILABLE)
+
     if user is None or not user.is_active or not user.check_password(password):
         return Response({"error": "Invalid credentials."}, status=status.HTTP_401_UNAUTHORIZED)
 
@@ -374,10 +429,16 @@ def token_refresh(request):
     if claims.get("type") != "refresh":
         return Response({"error": "Not a refresh token."}, status=status.HTTP_401_UNAUTHORIZED)
 
+    # A malformed subject id is a real 401; a cold-connection error is not --
+    # retry then surface 503 so a transient blip doesn't log the user out
+    # (the client's auth interceptor treats a failed refresh as logout).
     try:
-        user = User.objects(id=claims.get("sub")).first()
+        user = _read_with_retry(lambda: User.objects(id=claims.get("sub")).first())
     except ValidationError:
         user = None
+    except PyMongoError:
+        logger.error("token_refresh: Mongo unavailable after retries", exc_info=True)
+        return Response(_DB_WARMING_RESPONSE, status=status.HTTP_503_SERVICE_UNAVAILABLE)
     if user is None or not user.is_active:
         return Response({"error": "User not found or inactive."}, status=status.HTTP_401_UNAUTHORIZED)
 

--- a/frontend/src/components/Auth/Login.js
+++ b/frontend/src/components/Auth/Login.js
@@ -31,6 +31,43 @@ import {
   PasskeyError,
 } from "../../services/passkeys";
 
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// A login failure is "transient" when there's no HTTP response (network
+// error / client timeout) or the server returns 5xx -- including the 503
+// the backend now emits while a cold Mongo connection warms up. A 4xx
+// (401 bad credentials, 400 bad request) is a definitive answer and is
+// never retried.
+const isTransientError = (error) => {
+  const status = error?.response?.status;
+  if (status == null) return true; // no response -> network / timeout
+  return status >= 500;
+};
+
+// The backend can spin down when idle; the first sign-in after a wake-up
+// may bounce before the DB connection is warm. Retry the request a couple
+// of times on transient failures so the user's single click succeeds
+// instead of forcing them to mash "Sign in" again. `onRetry` lets the UI
+// surface a "waking up" hint before the wait.
+const LOGIN_RETRY_ATTEMPTS = 3;
+const LOGIN_RETRY_DELAY_MS = 1500;
+
+const postLoginWithRetry = async (credentials, { onRetry } = {}) => {
+  let lastError;
+  for (let attempt = 0; attempt < LOGIN_RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await axios.post(`${API_URL}/users/login/`, credentials);
+    } catch (error) {
+      lastError = error;
+      const hasNext = attempt < LOGIN_RETRY_ATTEMPTS - 1;
+      if (!isTransientError(error) || !hasNext) throw error;
+      if (onRetry) onRetry(attempt + 1);
+      await sleep(LOGIN_RETRY_DELAY_MS);
+    }
+  }
+  throw lastError;
+};
+
 const Login = () => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -55,11 +92,19 @@ const Login = () => {
       return;
     }
     setLoading(true);
+    let warmingNotified = false;
     try {
-      const response = await axios.post(`${API_URL}/users/login/`, {
-        username,
-        password,
-      });
+      const response = await postLoginWithRetry(
+        { username, password },
+        {
+          onRetry: () => {
+            // Only nudge the user once, no matter how many retries run.
+            if (warmingNotified) return;
+            warmingNotified = true;
+            toast.info("Waking up our servers - hang tight…");
+          },
+        },
+      );
       const { access, refresh } = response.data;
       if (access) {
         setTokens(access, refresh);

--- a/frontend/src/components/Auth/Login.js
+++ b/frontend/src/components/Auth/Login.js
@@ -88,7 +88,7 @@ const Login = () => {
 
   const handleLogin = async () => {
     if (!username || !password) {
-      toast.warning("Please fill in both your username and password.");
+      toast.warning("Please fill in both your username or email and password.");
       return;
     }
     setLoading(true);
@@ -186,7 +186,7 @@ const Login = () => {
           </Typography>
 
           <TextField
-            label="Username"
+            label="Username or email"
             variant="outlined"
             fullWidth
             value={username}


### PR DESCRIPTION
Two auth sign-in bugs.

## 1. Can't sign in with a valid email (the 401 everyone hit)

Signing in with a correct **email + password** returned `401 Invalid credentials`. `login` matched on `username` **only**, but the field is labelled "Username" and users routinely type their email — so a valid email/password pair resolved no user and was rejected.

- **Backend** (`users/views.py`): `login` resolves the identifier by username first, then falls back to a **case-insensitive email match** (`email__iexact`) when the input contains `@`. Wrong password on a found account still 401s.
- **Frontend** (`Auth/Login.js`): field relabelled **"Username or email"**; empty-field warning updated.

## 2. Cold start masquerading as invalid credentials

The deploy tier spins down when idle and the mongoengine connection is lazy, so the first Mongo read after a wake-up can exceed `serverSelectionTimeoutMS` and raise a `PyMongoError`. `login` didn't distinguish a connection failure from "wrong password".

- **Backend**: `_read_with_retry` re-runs a Mongo read a few times with short back-off **on `PyMongoError` only** (empty result isn't retried — real bad creds stay fast). `login` + `token_refresh` use it; on persistent failure they return **`503` "Service is waking up…"** instead of a misleading 401/500.
- **Frontend**: `postLoginWithRetry` retries transient failures (no response / 5xx incl. 503), **never a 4xx**, with a one-time "waking up" toast.

## Testing

`tests/test_auth_endpoints.py` (mongomock): email login (success / case-insensitive / wrong-password→401); `TestReadWithRetry`; cold-DB→503; cold-then-warm→200. **26 passed**. Frontend: eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)