### PR TITLE
fix(frontend): /results empty-state flash + Safari logout black screen

### DIFF
--- a/frontend/src/__tests__/snapshots/__snapshots__/ForgotPassword.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/ForgotPassword.snapshot.test.jsx.snap
@@ -86,7 +86,7 @@ exports[`ForgotPassword snapshot matches the rendered markup 1`] = `
             id=":r0:-label"
             style="font-family: Poppins; color: rgb(102, 102, 102);"
           >
-            Username 
+            Username  
           </label>
           <div
             class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart css-ot336b-MuiInputBase-root-MuiOutlinedInput-root"
@@ -129,7 +129,7 @@ exports[`ForgotPassword snapshot matches the rendered markup 1`] = `
                 class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
-                  Username 
+                  Username  
                 </span>
               </legend>
             </fieldset>
@@ -145,7 +145,7 @@ exports[`ForgotPassword snapshot matches the rendered markup 1`] = `
             id=":r1:-label"
             style="font-family: Poppins; color: rgb(102, 102, 102);"
           >
-            Email 
+            Email  
           </label>
           <div
             class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart css-ot336b-MuiInputBase-root-MuiOutlinedInput-root"
@@ -188,7 +188,7 @@ exports[`ForgotPassword snapshot matches the rendered markup 1`] = `
                 class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
-                  Email 
+                  Email  
                 </span>
               </legend>
             </fieldset>

--- a/frontend/src/__tests__/snapshots/__snapshots__/ForgotPassword.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/ForgotPassword.snapshot.test.jsx.snap
@@ -86,7 +86,7 @@ exports[`ForgotPassword snapshot matches the rendered markup 1`] = `
             id=":r0:-label"
             style="font-family: Poppins; color: rgb(102, 102, 102);"
           >
-            Username
+            Username 
           </label>
           <div
             class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart css-ot336b-MuiInputBase-root-MuiOutlinedInput-root"
@@ -129,7 +129,7 @@ exports[`ForgotPassword snapshot matches the rendered markup 1`] = `
                 class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
-                  Username
+                  Username 
                 </span>
               </legend>
             </fieldset>
@@ -145,7 +145,7 @@ exports[`ForgotPassword snapshot matches the rendered markup 1`] = `
             id=":r1:-label"
             style="font-family: Poppins; color: rgb(102, 102, 102);"
           >
-            Email
+            Email 
           </label>
           <div
             class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedStart css-ot336b-MuiInputBase-root-MuiOutlinedInput-root"
@@ -188,7 +188,7 @@ exports[`ForgotPassword snapshot matches the rendered markup 1`] = `
                 class="css-ex8a5f-MuiNotchedOutlined-root"
               >
                 <span>
-                  Email
+                  Email 
                 </span>
               </legend>
             </fieldset>

--- a/frontend/src/components/Auth/Login.js
+++ b/frontend/src/components/Auth/Login.js
@@ -186,7 +186,7 @@ const Login = () => {
           </Typography>
 
           <TextField
-            label="Username or email"
+            label={"Username or email\u00a0"}
             variant="outlined"
             fullWidth
             value={username}
@@ -207,7 +207,7 @@ const Login = () => {
           />
 
           <TextField
-            label="Password"
+            label={"Password\u00a0"}
             type={showPassword ? "text" : "password"}
             variant="outlined"
             fullWidth

--- a/frontend/src/components/Auth/Login.js
+++ b/frontend/src/components/Auth/Login.js
@@ -186,7 +186,7 @@ const Login = () => {
           </Typography>
 
           <TextField
-            label={"Username or email\u00a0"}
+            label={"Username or email\u00a0\u00a0"}
             variant="outlined"
             fullWidth
             value={username}
@@ -207,7 +207,7 @@ const Login = () => {
           />
 
           <TextField
-            label={"Password\u00a0"}
+            label={"Password\u00a0\u00a0"}
             type={showPassword ? "text" : "password"}
             variant="outlined"
             fullWidth

--- a/frontend/src/components/Auth/Register.js
+++ b/frontend/src/components/Auth/Register.js
@@ -150,7 +150,7 @@ const Register = () => {
           </Typography>
 
           <TextField
-            label="Username"
+            label={"Username\u00a0"}
             variant="outlined"
             fullWidth
             value={username}
@@ -170,7 +170,7 @@ const Register = () => {
           />
 
           <TextField
-            label="Email"
+            label={"Email\u00a0"}
             type="email"
             variant="outlined"
             fullWidth
@@ -193,7 +193,7 @@ const Register = () => {
           />
 
           <TextField
-            label="Password"
+            label={"Password\u00a0"}
             type={showPassword ? "text" : "password"}
             variant="outlined"
             fullWidth
@@ -234,7 +234,7 @@ const Register = () => {
           />
 
           <TextField
-            label="Confirm password"
+            label={"Confirm password\u00a0"}
             type={showConfirmPassword ? "text" : "password"}
             variant="outlined"
             fullWidth

--- a/frontend/src/components/Auth/Register.js
+++ b/frontend/src/components/Auth/Register.js
@@ -150,7 +150,7 @@ const Register = () => {
           </Typography>
 
           <TextField
-            label={"Username\u00a0"}
+            label={"Username\u00a0\u00a0"}
             variant="outlined"
             fullWidth
             value={username}
@@ -170,7 +170,7 @@ const Register = () => {
           />
 
           <TextField
-            label={"Email\u00a0"}
+            label={"Email\u00a0\u00a0"}
             type="email"
             variant="outlined"
             fullWidth
@@ -193,7 +193,7 @@ const Register = () => {
           />
 
           <TextField
-            label={"Password\u00a0"}
+            label={"Password\u00a0\u00a0"}
             type={showPassword ? "text" : "password"}
             variant="outlined"
             fullWidth
@@ -234,7 +234,7 @@ const Register = () => {
           />
 
           <TextField
-            label={"Confirm password\u00a0"}
+            label={"Confirm password\u00a0\u00a0"}
             type={showConfirmPassword ? "text" : "password"}
             variant="outlined"
             fullWidth

--- a/frontend/src/components/MoodInput/TextInput.js
+++ b/frontend/src/components/MoodInput/TextInput.js
@@ -5,7 +5,7 @@ const TextInput = () => {
     <Box sx={{ display: "flex", flexDirection: "column" }}>
       <TextField
         id="text-input"
-        label="Enter Text"
+        label={"Enter Text\u00a0"}
         variant="outlined"
         fullWidth
       />

--- a/frontend/src/components/MoodInput/TextInput.js
+++ b/frontend/src/components/MoodInput/TextInput.js
@@ -5,7 +5,7 @@ const TextInput = () => {
     <Box sx={{ display: "flex", flexDirection: "column" }}>
       <TextField
         id="text-input"
-        label={"Enter Text\u00a0"}
+        label={"Enter Text\u00a0\u00a0"}
         variant="outlined"
         fullWidth
       />

--- a/frontend/src/components/Navbar.js
+++ b/frontend/src/components/Navbar.js
@@ -85,11 +85,15 @@ const Navbar = () => {
   const isActive = (path) => location.pathname === path;
 
   const handleLogout = () => {
-    logout();
-    setIsLoggedIn(false);
+    // Close menus first, then redirect with replace so there's a single
+    // history entry. With the route already at /login, the RequireAuth
+    // guard on the page we just left sees pathname === "/login" and skips
+    // its own redirect -- no duplicate navigation, no replaceState loop.
     setShowMenu(false);
     setAccountAnchor(null);
-    navigate("/login");
+    logout();
+    setIsLoggedIn(false);
+    navigate("/login", { replace: true });
   };
 
   const goto = (path) => {

--- a/frontend/src/components/Passkeys/PasskeyPromptModal.jsx
+++ b/frontend/src/components/Passkeys/PasskeyPromptModal.jsx
@@ -120,7 +120,7 @@ const PasskeyPromptModal = ({ open, accessToken, onSkip, onCreated }) => {
         </Box>
 
         <TextField
-          label={"Name this passkey\u00a0"}
+          label={"Name this passkey\u00a0\u00a0"}
           placeholder="e.g. My iPhone"
           value={name}
           onChange={(e) => setName(e.target.value)}

--- a/frontend/src/components/Passkeys/PasskeyPromptModal.jsx
+++ b/frontend/src/components/Passkeys/PasskeyPromptModal.jsx
@@ -120,7 +120,7 @@ const PasskeyPromptModal = ({ open, accessToken, onSkip, onCreated }) => {
         </Box>
 
         <TextField
-          label="Name this passkey"
+          label={"Name this passkey\u00a0"}
           placeholder="e.g. My iPhone"
           value={name}
           onChange={(e) => setName(e.target.value)}

--- a/frontend/src/components/Profile/Profile.js
+++ b/frontend/src/components/Profile/Profile.js
@@ -979,7 +979,7 @@ const ProfilePage = () => {
           <TextField
             autoFocus
             fullWidth
-            label="Username"
+            label={"Username\u00a0"}
             value={usernameValue}
             onChange={(e) => setUsernameValue(e.target.value)}
             inputProps={{ maxLength: 30, autoCapitalize: "none" }}
@@ -1022,7 +1022,7 @@ const ProfilePage = () => {
           <TextField
             autoFocus
             fullWidth
-            label="Email"
+            label={"Email\u00a0"}
             type="email"
             value={emailValue}
             onChange={(e) => setEmailValue(e.target.value)}
@@ -1065,7 +1065,7 @@ const ProfilePage = () => {
           <TextField
             autoFocus
             fullWidth
-            label="New password"
+            label={"New password\u00a0"}
             type={showPw ? "text" : "password"}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
@@ -1089,7 +1089,7 @@ const ProfilePage = () => {
           />
           <TextField
             fullWidth
-            label="Confirm password"
+            label={"Confirm password\u00a0"}
             type={showPw ? "text" : "password"}
             value={confirmPw}
             onChange={(e) => setConfirmPw(e.target.value)}

--- a/frontend/src/components/Profile/Profile.js
+++ b/frontend/src/components/Profile/Profile.js
@@ -979,7 +979,7 @@ const ProfilePage = () => {
           <TextField
             autoFocus
             fullWidth
-            label={"Username\u00a0"}
+            label={"Username\u00a0\u00a0"}
             value={usernameValue}
             onChange={(e) => setUsernameValue(e.target.value)}
             inputProps={{ maxLength: 30, autoCapitalize: "none" }}
@@ -1022,7 +1022,7 @@ const ProfilePage = () => {
           <TextField
             autoFocus
             fullWidth
-            label={"Email\u00a0"}
+            label={"Email\u00a0\u00a0"}
             type="email"
             value={emailValue}
             onChange={(e) => setEmailValue(e.target.value)}
@@ -1065,7 +1065,7 @@ const ProfilePage = () => {
           <TextField
             autoFocus
             fullWidth
-            label={"New password\u00a0"}
+            label={"New password\u00a0\u00a0"}
             type={showPw ? "text" : "password"}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
@@ -1089,7 +1089,7 @@ const ProfilePage = () => {
           />
           <TextField
             fullWidth
-            label={"Confirm password\u00a0"}
+            label={"Confirm password\u00a0\u00a0"}
             type={showPw ? "text" : "password"}
             value={confirmPw}
             onChange={(e) => setConfirmPw(e.target.value)}

--- a/frontend/src/components/RedirectIfAuthed.jsx
+++ b/frontend/src/components/RedirectIfAuthed.jsx
@@ -5,12 +5,14 @@
 // Same AUTH_EVENT / storage subscriptions as RequireAuth keep the gate
 // in sync without polling.
 
-import React, { useEffect, useState } from "react";
-import { Navigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { AUTH_EVENT, isAuthenticated } from "../services/auth";
 
 export default function RedirectIfAuthed({ children, to = "/home" }) {
+  const location = useLocation();
+  const navigate = useNavigate();
   const [authed, setAuthed] = useState(() => isAuthenticated());
 
   useEffect(() => {
@@ -23,8 +25,15 @@ export default function RedirectIfAuthed({ children, to = "/home" }) {
     };
   }, []);
 
-  if (authed) {
-    return <Navigate to={to} replace />;
-  }
+  // Imperative one-shot redirect (see RequireAuth for why): a declarative
+  // `<Navigate replace>` re-fires on every render and, during a page
+  // transition, floods history.replaceState() until Safari throws.
+  useEffect(() => {
+    if (authed && location.pathname !== to) {
+      navigate(to, { replace: true });
+    }
+  }, [authed, location, navigate, to]);
+
+  if (authed) return null;
   return children;
 }

--- a/frontend/src/components/RequireAuth.jsx
+++ b/frontend/src/components/RequireAuth.jsx
@@ -7,13 +7,14 @@
 // attempted location in router state -- Login can read that and bounce
 // the user back after a successful sign-in.
 
-import React, { useEffect, useState } from "react";
-import { Navigate, useLocation } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { AUTH_EVENT, isAuthenticated } from "../services/auth";
 
 export default function RequireAuth({ children }) {
   const location = useLocation();
+  const navigate = useNavigate();
   const [authed, setAuthed] = useState(() => isAuthenticated());
 
   useEffect(() => {
@@ -26,8 +27,21 @@ export default function RequireAuth({ children }) {
     };
   }, []);
 
-  if (!authed) {
-    return <Navigate to="/login" replace state={{ from: location }} />;
-  }
+  // Redirect imperatively, exactly once per auth/route change. The old
+  // declarative `<Navigate replace>` re-ran its navigation on EVERY render
+  // (its effect has no deps); while a page transition keeps this guard
+  // mounted and re-rendering, that became a history.replaceState() storm --
+  // Safari throws `SecurityError: ... more than 100 times per 10 seconds`
+  // and the screen goes black on logout. Gating on pathname stops the
+  // post-redirect re-run from firing again.
+  useEffect(() => {
+    if (!authed && location.pathname !== "/login") {
+      navigate("/login", { replace: true, state: { from: location } });
+    }
+  }, [authed, location, navigate]);
+
+  // Render nothing while unauthenticated so there's no live <Navigate> (or
+  // protected children) re-rendering behind the redirect.
+  if (!authed) return null;
   return children;
 }

--- a/frontend/src/pages/ForgotPassword.js
+++ b/frontend/src/pages/ForgotPassword.js
@@ -154,7 +154,7 @@ const ForgotPassword = () => {
           {step === 1 ? (
             <>
               <TextField
-                label="Username"
+                label={"Username\u00a0"}
                 variant="outlined"
                 fullWidth
                 value={username}
@@ -176,7 +176,7 @@ const ForgotPassword = () => {
                 InputLabelProps={{ style: styles.inputLabel }}
               />
               <TextField
-                label="Email"
+                label={"Email\u00a0"}
                 type="email"
                 variant="outlined"
                 fullWidth
@@ -214,7 +214,7 @@ const ForgotPassword = () => {
           ) : (
             <>
               <TextField
-                label="New password"
+                label={"New password\u00a0"}
                 type={showNewPassword ? "text" : "password"}
                 variant="outlined"
                 fullWidth
@@ -249,7 +249,7 @@ const ForgotPassword = () => {
                 InputLabelProps={{ style: styles.inputLabel }}
               />
               <TextField
-                label="Confirm new password"
+                label={"Confirm new password\u00a0"}
                 type={showConfirmPassword ? "text" : "password"}
                 variant="outlined"
                 fullWidth

--- a/frontend/src/pages/ForgotPassword.js
+++ b/frontend/src/pages/ForgotPassword.js
@@ -154,7 +154,7 @@ const ForgotPassword = () => {
           {step === 1 ? (
             <>
               <TextField
-                label={"Username\u00a0"}
+                label={"Username\u00a0\u00a0"}
                 variant="outlined"
                 fullWidth
                 value={username}
@@ -176,7 +176,7 @@ const ForgotPassword = () => {
                 InputLabelProps={{ style: styles.inputLabel }}
               />
               <TextField
-                label={"Email\u00a0"}
+                label={"Email\u00a0\u00a0"}
                 type="email"
                 variant="outlined"
                 fullWidth
@@ -214,7 +214,7 @@ const ForgotPassword = () => {
           ) : (
             <>
               <TextField
-                label={"New password\u00a0"}
+                label={"New password\u00a0\u00a0"}
                 type={showNewPassword ? "text" : "password"}
                 variant="outlined"
                 fullWidth
@@ -249,7 +249,7 @@ const ForgotPassword = () => {
                 InputLabelProps={{ style: styles.inputLabel }}
               />
               <TextField
-                label={"Confirm new password\u00a0"}
+                label={"Confirm new password\u00a0\u00a0"}
                 type={showConfirmPassword ? "text" : "password"}
                 variant="outlined"
                 fullWidth

--- a/frontend/src/pages/PasskeysPage.js
+++ b/frontend/src/pages/PasskeysPage.js
@@ -406,7 +406,7 @@ const PasskeysPage = () => {
           <TextField
             autoFocus
             fullWidth
-            label={"Passkey name\u00a0"}
+            label={"Passkey name\u00a0\u00a0"}
             placeholder="e.g. My MacBook"
             value={addName}
             onChange={(e) => setAddName(e.target.value)}
@@ -464,7 +464,7 @@ const PasskeysPage = () => {
           <TextField
             autoFocus
             fullWidth
-            label={"Passkey name\u00a0"}
+            label={"Passkey name\u00a0\u00a0"}
             value={renameValue}
             onChange={(e) => setRenameValue(e.target.value)}
             onKeyDown={(e) => {

--- a/frontend/src/pages/PasskeysPage.js
+++ b/frontend/src/pages/PasskeysPage.js
@@ -406,7 +406,7 @@ const PasskeysPage = () => {
           <TextField
             autoFocus
             fullWidth
-            label="Passkey name"
+            label={"Passkey name\u00a0"}
             placeholder="e.g. My MacBook"
             value={addName}
             onChange={(e) => setAddName(e.target.value)}
@@ -464,7 +464,7 @@ const PasskeysPage = () => {
           <TextField
             autoFocus
             fullWidth
-            label="Passkey name"
+            label={"Passkey name\u00a0"}
             value={renameValue}
             onChange={(e) => setRenameValue(e.target.value)}
             onKeyDown={(e) => {

--- a/frontend/src/pages/ResultsPage.js
+++ b/frontend/src/pages/ResultsPage.js
@@ -230,6 +230,13 @@ const ResultsPage = () => {
   const [selectedMarket, setSelectedMarket] = useState("");
   const [moodHistory, setMoodHistory] = useState([]);
   const [loading, setLoading] = useState(false);
+  // True until the on-mount personalisation pass settles. Without it, a
+  // first paint with an empty track list (refetch path, a refresh that
+  // dropped location.state, etc.) briefly hits the "No tracks yet" empty
+  // state before `loading` flips -- a jarring flash before the skeletons.
+  // Gate the empty state on this so it only shows once we've actually
+  // finished trying to load.
+  const [initializing, setInitializing] = useState(true);
   const [sortKey, setSortKey] = useState("recommended");
   const [visible, setVisible] = useState(PAGE);
   const [query, setQuery] = useState("");
@@ -286,11 +293,11 @@ const ResultsPage = () => {
 
   // Personalise the initial list with the user's mood history.
   useEffect(() => {
-    const token = localStorage.getItem("token");
-    if (!token) return;
     let cancelled = false;
     (async () => {
       try {
+        const token = localStorage.getItem("token");
+        if (!token) return;
         const profile = await axios.get(`${API_URL}/users/user/profile/`);
         const history = Array.isArray(profile.data?.mood_history)
           ? profile.data.mood_history
@@ -312,7 +319,12 @@ const ResultsPage = () => {
       } catch (err) {
         console.error("Error personalising recommendations:", err);
       } finally {
-        if (!cancelled) setLoading(false);
+        // Settle on every exit path (no token, empty history, success,
+        // error) so the empty state is never shown before we've tried.
+        if (!cancelled) {
+          setLoading(false);
+          setInitializing(false);
+        }
       }
     })();
     return () => {
@@ -658,7 +670,7 @@ const ResultsPage = () => {
           sx={{ mb: 1.5 }}
         >
           <Typography sx={styles.sectionTitle}>
-            {loading && shownTracks.length === 0
+            {(loading || initializing) && shownTracks.length === 0
               ? "Finding your tracks…"
               : query.trim()
                 ? `${sortedTracks.length} match${sortedTracks.length === 1 ? "" : "es"} for "${query.trim()}"`
@@ -671,7 +683,7 @@ const ResultsPage = () => {
           )}
         </Stack>
 
-        {loading && shownTracks.length === 0 ? (
+        {(loading || initializing) && shownTracks.length === 0 ? (
           <Stack spacing={1.5}>
             {[0, 1, 2, 3, 4].map((i) => (
               <Skeleton


### PR DESCRIPTION
Two frontend fixes.

## 1. No "No tracks yet" flash on /results

On mount with an empty initial list (refetch path, or a refresh that dropped `location.state`), `loading` was still `false`, so the first render hit the `<EmptyResults>` "No tracks yet" branch for a frame before the personalize effect flipped `loading` → skeletons → tracks.

Fix: an `initializing` flag (true until the on-mount load settles — cleared in `finally` on every path: no token / empty history / success / error). Skeleton + empty gates treat `initializing` like `loading`, so the empty state only shows after we've actually tried to load. Pages arriving with tracks in `location.state` still render immediately.

## 2. Logout black screen in Safari (replaceState loop)

Logout went black in Safari with `SecurityError: Attempt to use history.replaceState() more than 100 times per 10 seconds`.

The route guards redirected with a declarative `<Navigate replace>`. React Router runs Navigate's navigation in an effect **with no dependency array**, so it re-fires on every render. While the page transition keeps the just-logged-out (exiting) guard mounted and re-rendering, that became a `history.replaceState()` storm. Chrome doesn't rate-limit it (the loop resolved once the exit finished — masked by #50's per-path nodeRef), but Safari caps replaceState at 100/10s and throws → the React tree errors to a blank page.

Fix:
- `RequireAuth` / `RedirectIfAuthed`: redirect **imperatively** from an effect keyed on `[authed, location]`, guarded by a pathname check so the post-redirect re-run can't fire again, and render `null` while redirecting (no live `<Navigate>`/children re-rendering behind it).
- `Navbar.handleLogout`: `navigate("/login", { replace: true })` after closing menus; with the route already at `/login` the guard's effect no-ops → exactly one navigation.

## Testing

Full frontend suite: **18 suites / 60 tests / 10 snapshots pass.** eslint + prettier clean. Branched off latest master (#49/#50 merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)