### PR TITLE
fix(frontend): kill logout replaceState storm (Safari black screen)

### DIFF
--- a/frontend/src/components/RedirectIfAuthed.jsx
+++ b/frontend/src/components/RedirectIfAuthed.jsx
@@ -5,7 +5,7 @@
 // Same AUTH_EVENT / storage subscriptions as RequireAuth keep the gate
 // in sync without polling.
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { AUTH_EVENT, isAuthenticated } from "../services/auth";
@@ -14,6 +14,7 @@ export default function RedirectIfAuthed({ children, to = "/home" }) {
   const location = useLocation();
   const navigate = useNavigate();
   const [authed, setAuthed] = useState(() => isAuthenticated());
+  const redirected = useRef(false);
 
   useEffect(() => {
     const sync = () => setAuthed(isAuthenticated());
@@ -25,13 +26,20 @@ export default function RedirectIfAuthed({ children, to = "/home" }) {
     };
   }, []);
 
-  // Imperative one-shot redirect (see RequireAuth for why): a declarative
-  // `<Navigate replace>` re-fires on every render and, during a page
-  // transition, floods history.replaceState() until Safari throws.
+  // Imperative redirect, ref-guarded so it fires only ONCE per
+  // authenticated episode. See RequireAuth for the full rationale: during
+  // a page transition the exiting guard's `useLocation()` returns the
+  // frozen old path, so a pathname check is unreliable and the navigate
+  // would re-fire on every transition re-render -- a history.replaceState()
+  // storm that crashes Safari (login has the same shape as logout).
   useEffect(() => {
-    if (authed && location.pathname !== to) {
-      navigate(to, { replace: true });
+    if (!authed) {
+      redirected.current = false;
+      return;
     }
+    if (redirected.current) return;
+    redirected.current = true;
+    navigate(to, { replace: true });
   }, [authed, location, navigate, to]);
 
   if (authed) return null;

--- a/frontend/src/components/RequireAuth.jsx
+++ b/frontend/src/components/RequireAuth.jsx
@@ -7,7 +7,7 @@
 // attempted location in router state -- Login can read that and bounce
 // the user back after a successful sign-in.
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { AUTH_EVENT, isAuthenticated } from "../services/auth";
@@ -16,6 +16,9 @@ export default function RequireAuth({ children }) {
   const location = useLocation();
   const navigate = useNavigate();
   const [authed, setAuthed] = useState(() => isAuthenticated());
+  // Fire the redirect at most once per unauthenticated episode. Re-arms
+  // when the user becomes authenticated again.
+  const redirected = useRef(false);
 
   useEffect(() => {
     const sync = () => setAuthed(isAuthenticated());
@@ -27,21 +30,29 @@ export default function RequireAuth({ children }) {
     };
   }, []);
 
-  // Redirect imperatively, exactly once per auth/route change. The old
-  // declarative `<Navigate replace>` re-ran its navigation on EVERY render
-  // (its effect has no deps); while a page transition keeps this guard
-  // mounted and re-rendering, that became a history.replaceState() storm --
-  // Safari throws `SecurityError: ... more than 100 times per 10 seconds`
-  // and the screen goes black on logout. Gating on pathname stops the
-  // post-redirect re-run from firing again.
+  // Redirect imperatively, guarded by a ref so it can fire only ONCE.
+  //
+  // Why the ref (a pathname check is not enough): during the page
+  // transition, react-transition-group keeps this guard mounted on the
+  // exiting route while react-router renders it inside `<Routes
+  // location={frozenOldLocation}>`. That overrides the location context,
+  // so `useLocation()` here returns the OLD path (e.g. /home), not /login
+  // -- a `pathname !== "/login"` check passes and the navigate re-fires on
+  // every re-render the transition triggers. That floods
+  // history.replaceState() until Safari throws `SecurityError: ... more
+  // than 100 times per 10 seconds` and the screen goes black on logout.
   useEffect(() => {
-    if (!authed && location.pathname !== "/login") {
-      navigate("/login", { replace: true, state: { from: location } });
+    if (authed) {
+      redirected.current = false;
+      return;
     }
+    if (redirected.current) return;
+    redirected.current = true;
+    navigate("/login", { replace: true, state: { from: location } });
   }, [authed, location, navigate]);
 
-  // Render nothing while unauthenticated so there's no live <Navigate> (or
-  // protected children) re-rendering behind the redirect.
+  // Render nothing while unauthenticated so no protected children re-render
+  // behind the redirect.
   if (!authed) return null;
   return children;
 }


### PR DESCRIPTION
## Problem

Logging out crashes to a black screen **in Safari**:
`SecurityError: Attempt to use history.replaceState() more than 100 times per 10 seconds`.

Persisted even after the earlier change from declarative `<Navigate replace>` to an imperative effect with a `pathname !== "/login"` check.

## Root cause

The pathname check was unreliable. During the page transition, react-transition-group keeps the **exiting** route's guard mounted while react-router renders it inside `<Routes location={frozenOldLocation}>`. That **overrides the location context**, so `useLocation()` inside the guard returns the *old* path (e.g. `/home`), not `/login`.

→ `pathname !== "/login"` passes → `navigate("/login", { replace })` re-fires on every re-render the transition triggers → `history.replaceState()` flood. Chrome tolerates it; Safari caps at 100/10s and throws, blanking the page.

## Fix

Guard the redirect with a `useRef` so each guard navigates **at most once** per episode, re-arming only when auth flips back:

```js
useEffect(() => {
  if (authed) { redirected.current = false; return; }   // RequireAuth
  if (redirected.current) return;
  redirected.current = true;
  navigate("/login", { replace: true, state: { from: location } });
}, [authed, location, navigate]);
```

Independent of whatever location the transition feeds `useLocation()`. Login has the same shape (RedirectIfAuthed), so both guards are hardened.

## Testing

60 tests / 10 snapshots pass; eslint + prettier clean. Branched off latest master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)