### PR TITLE
fix(frontend): recolor whole app instantly on dark/light toggle

### DIFF
--- a/frontend/src/context/DarkModeContext.js
+++ b/frontend/src/context/DarkModeContext.js
@@ -10,9 +10,19 @@ export const DarkModeProvider = ({ children }) => {
     localStorage.getItem("darkMode") === "true",
   );
 
-  // Effect to sync with localStorage when state changes
+  // Sync to localStorage AND drive the global theme classes on <body>.
+  // styles.css defines `body.dark-mode` / `body.light-mode` rules (page
+  // background, default text, raw button/input/link colours, scrollbars),
+  // but nothing was ever applying those classes -- so toggling the switch
+  // only re-coloured the React components that read this context inline and
+  // left the body-level theming stuck until a reload. Toggling the class
+  // here (on mount and on every change) recolours the whole app the instant
+  // the switch flips.
   useEffect(() => {
     localStorage.setItem("darkMode", isDarkMode);
+    const body = document.body;
+    body.classList.toggle("dark-mode", isDarkMode);
+    body.classList.toggle("light-mode", !isDarkMode);
   }, [isDarkMode]);
 
   // Function to toggle dark mode


### PR DESCRIPTION
## Problem

Flipping the dark/light switch didn't recolor the whole app immediately — the body-level theme (page background, default text, raw button/input/link colors, scrollbars) only updated after a reload.

## Cause

`styles.css` defines global `body.dark-mode` / `body.light-mode` rules, but **nothing ever applied those classes to `<body>`**. `DarkModeProvider` only wrote to `localStorage` and exposed `isDarkMode` via context. Components that read the context inline (`isDark ? … : …`) re-colored on toggle, but everything keyed off the body class stayed stuck.

## Fix

Toggle the body classes from the provider effect (runs on mount and on every change):

```js
useEffect(() => {
  localStorage.setItem("darkMode", isDarkMode);
  document.body.classList.toggle("dark-mode", isDarkMode);
  document.body.classList.toggle("light-mode", !isDarkMode);
}, [isDarkMode]);
```

Now the entire app recolors the instant the switch flips — no reload.

## Testing

60 tests / 10 snapshots pass; eslint + prettier clean. Branched off latest master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)