### PR TITLE
fix(frontend): theme link rule no longer recolors MUI links (footer)

### DIFF
--- a/frontend/src/styles/styles.css
+++ b/frontend/src/styles/styles.css
@@ -147,12 +147,18 @@ body.dark-mode textarea:focus {
   animation: fadeIn 1s ease-in-out;
 }
 
-/* Dark mode link colors */
-body.dark-mode a {
+/* Theme link colors for plain content anchors only.
+   `:not([class*="Mui"])` excludes MUI-styled anchors (Link, Button,
+   IconButton render <a>). Those carry their own colour via an emotion
+   class, but `body.<mode> a` (specificity 0,1,2) outranks that emotion
+   class (0,1,0) -- so without the exclusion these rules repaint every MUI
+   link the brand red, making e.g. the footer links unreadable on the red
+   gradient. */
+body.dark-mode a:not([class*="Mui"]) {
   color: #ff6666;
 }
 
-body.light-mode a {
+body.light-mode a:not([class*="Mui"]) {
   color: #ff4d4d;
 }
 


### PR DESCRIPTION
## Problem

Footer links render in brand red on the red gradient — effectively invisible. (Surfaced once the dark/light body class started being applied, #54.)

## Cause

`styles.css` has:

```css
body.dark-mode a  { color: #ff6666; }
body.light-mode a { color: #ff4d4d; }
```

`body.<mode> a` has specificity **0,1,2** — higher than the emotion class MUI puts on its `Link` / `Button` / `IconButton` anchors (**0,1,0**). So the theme rule repaints **every** MUI link the brand color, overriding the footer's own `color: white`.

## Fix

Scope the theme link color to plain content anchors only:

```css
body.dark-mode a:not([class*="Mui"])  { color: #ff6666; }
body.light-mode a:not([class*="Mui"]) { color: #ff4d4d; }
```

MUI-styled links keep their component color (footer links go back to white, readable on the gradient); raw content `<a>` still get the themed color.

## Testing

60 tests / 10 snapshots pass; prettier clean. Branched off latest master (includes #54).

🤖 Generated with [Claude Code](https://claude.com/claude-code)