### PR TITLE
fix(frontend): animate landing hero highlight cards on reveal

### DIFF
--- a/frontend/src/__tests__/snapshots/__snapshots__/LandingPage.snapshot.test.jsx.snap
+++ b/frontend/src/__tests__/snapshots/__snapshots__/LandingPage.snapshot.test.jsx.snap
@@ -116,11 +116,11 @@ exports[`LandingPage snapshot matches the rendered markup 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 css-1akpnp7-MuiGrid-root"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-wg4xta-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 reveal reveal-delay-1 css-wg4xta-MuiGrid-root is-visible"
+                data-reveal="true"
               >
                 <div
-                  class="reveal reveal-delay-1 MuiBox-root css-11uya56 is-visible"
-                  data-reveal="true"
+                  class="MuiBox-root css-11uya56"
                 >
                   <div
                     class="MuiBox-root css-k400sw"
@@ -150,11 +150,11 @@ exports[`LandingPage snapshot matches the rendered markup 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-wg4xta-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 reveal reveal-delay-2 css-wg4xta-MuiGrid-root is-visible"
+                data-reveal="true"
               >
                 <div
-                  class="reveal reveal-delay-2 MuiBox-root css-11uya56 is-visible"
-                  data-reveal="true"
+                  class="MuiBox-root css-11uya56"
                 >
                   <div
                     class="MuiBox-root css-k400sw"
@@ -184,11 +184,11 @@ exports[`LandingPage snapshot matches the rendered markup 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 css-wg4xta-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 reveal reveal-delay-3 css-wg4xta-MuiGrid-root is-visible"
+                data-reveal="true"
               >
                 <div
-                  class="reveal reveal-delay-3 MuiBox-root css-11uya56 is-visible"
-                  data-reveal="true"
+                  class="MuiBox-root css-11uya56"
                 >
                   <div
                     class="MuiBox-root css-k400sw"

--- a/frontend/src/pages/LandingPage.js
+++ b/frontend/src/pages/LandingPage.js
@@ -204,11 +204,19 @@ const LandingPage = () => {
                 {heroHighlights.map((item, index) => {
                   const HighlightIcon = item.icon;
                   return (
-                    <Grid item xs={12} sm={4} key={item.label}>
-                      <Box
-                        sx={styles.heroHighlightCard}
-                        {...getRevealProps((index % 3) + 1)}
-                      >
+                    <Grid
+                      item
+                      xs={12}
+                      sm={4}
+                      key={item.label}
+                      {...getRevealProps((index % 3) + 1)}
+                    >
+                      {/* Reveal lives on the Grid item, not the card: the
+                          card has its own `transition` (hover lift) which
+                          would override `.reveal`'s opacity/transform
+                          transition and kill the fade-in the other sections
+                          have. */}
+                      <Box sx={styles.heroHighlightCard}>
                         <Box sx={styles.iconBadge}>
                           <HighlightIcon fontSize="small" />
                         </Box>


### PR DESCRIPTION
## Problem

The three hero highlight cards on the landing page — **3 Input Modes / Adaptive Engine / Cross-Platform** — don't fade/slide in on reveal like the other landing sections; they just pop in.

## Cause

The reveal class (`getRevealProps`) was applied to the **same Box that carries the card's own `transition`** (the hover-lift). MUI's emotion `transition` overrides `.reveal`'s `opacity`/`transform` transition, so the reveal state change snaps instead of animating. The hero panel and the other reveal sections animate fine because they have no competing `transition`.

## Fix

Move the reveal onto the **Grid item** (no transition) and keep the hover transition on the inner card. The cards now reveal with the same fade + slide as everything else; hover still works.

## Testing

LandingPage snapshot updated for the moved class. 60 tests / 10 snapshots pass; eslint + prettier clean. Branched off latest master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)