### PR TITLE
fix(frontend): reserve page height so footer stays at bottom while loading

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -78,101 +78,107 @@ function AppLayout() {
   const timeout = reduceMotion ? 0 : { enter: 480, exit: 300 };
 
   return (
-    <>
+    <div className="app-shell">
       {!hideNavbar && <Navbar />}
-      <SwitchTransition mode="out-in">
-        <CSSTransition
-          key={location.pathname}
-          nodeRef={nodeRef}
-          timeout={timeout}
-          classNames="page"
-          appear
-          unmountOnExit
-        >
-          <div ref={nodeRef} className="page-anim">
-            <Routes location={location}>
-              {/* Public routes -- landing, auth, legal. Auth pages bounce a
+      {/* `app-main` flex-grows to fill the viewport so the footer always
+          sits at the bottom -- even mid-load when the routed page hasn't
+          rendered any height yet. Previously an empty/short page let the
+          footer ride up to just under the navbar while content loaded. */}
+      <div className="app-main">
+        <SwitchTransition mode="out-in">
+          <CSSTransition
+            key={location.pathname}
+            nodeRef={nodeRef}
+            timeout={timeout}
+            classNames="page"
+            appear
+            unmountOnExit
+          >
+            <div ref={nodeRef} className="page-anim">
+              <Routes location={location}>
+                {/* Public routes -- landing, auth, legal. Auth pages bounce a
             signed-in user back to /home so they never see the form. */}
-              <Route path="/" element={<LandingPage />} />
-              <Route
-                path="/login"
-                element={
-                  <RedirectIfAuthed>
-                    <Login />
-                  </RedirectIfAuthed>
-                }
-              />
-              <Route
-                path="/register"
-                element={
-                  <RedirectIfAuthed>
-                    <Register />
-                  </RedirectIfAuthed>
-                }
-              />
-              <Route
-                path="/forgot-password"
-                element={
-                  <RedirectIfAuthed>
-                    <ForgotPassword />
-                  </RedirectIfAuthed>
-                }
-              />
-              <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
-              <Route
-                path="/terms-of-service"
-                element={<TermsOfServicePage />}
-              />
+                <Route path="/" element={<LandingPage />} />
+                <Route
+                  path="/login"
+                  element={
+                    <RedirectIfAuthed>
+                      <Login />
+                    </RedirectIfAuthed>
+                  }
+                />
+                <Route
+                  path="/register"
+                  element={
+                    <RedirectIfAuthed>
+                      <Register />
+                    </RedirectIfAuthed>
+                  }
+                />
+                <Route
+                  path="/forgot-password"
+                  element={
+                    <RedirectIfAuthed>
+                      <ForgotPassword />
+                    </RedirectIfAuthed>
+                  }
+                />
+                <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
+                <Route
+                  path="/terms-of-service"
+                  element={<TermsOfServicePage />}
+                />
 
-              {/* Gated feature routes -- redirect to /login when signed out. */}
-              <Route
-                path="/home"
-                element={
-                  <RequireAuth>
-                    <HomePage />
-                  </RequireAuth>
-                }
-              />
-              <Route
-                path="/profile"
-                element={
-                  <RequireAuth>
-                    <ProfilePage />
-                  </RequireAuth>
-                }
-              />
-              <Route
-                path="/passkeys"
-                element={
-                  <RequireAuth>
-                    <PasskeysPage />
-                  </RequireAuth>
-                }
-              />
-              <Route
-                path="/results"
-                element={
-                  <RequireAuth>
-                    <ResultsPage />
-                  </RequireAuth>
-                }
-              />
-              <Route
-                path="/recommendations"
-                element={
-                  <RequireAuth>
-                    <RecommendationsPage />
-                  </RequireAuth>
-                }
-              />
+                {/* Gated feature routes -- redirect to /login when signed out. */}
+                <Route
+                  path="/home"
+                  element={
+                    <RequireAuth>
+                      <HomePage />
+                    </RequireAuth>
+                  }
+                />
+                <Route
+                  path="/profile"
+                  element={
+                    <RequireAuth>
+                      <ProfilePage />
+                    </RequireAuth>
+                  }
+                />
+                <Route
+                  path="/passkeys"
+                  element={
+                    <RequireAuth>
+                      <PasskeysPage />
+                    </RequireAuth>
+                  }
+                />
+                <Route
+                  path="/results"
+                  element={
+                    <RequireAuth>
+                      <ResultsPage />
+                    </RequireAuth>
+                  }
+                />
+                <Route
+                  path="/recommendations"
+                  element={
+                    <RequireAuth>
+                      <RecommendationsPage />
+                    </RequireAuth>
+                  }
+                />
 
-              <Route path="*" element={<NotFoundPage />} />
-            </Routes>
-          </div>
-        </CSSTransition>
-      </SwitchTransition>
+                <Route path="*" element={<NotFoundPage />} />
+              </Routes>
+            </div>
+          </CSSTransition>
+        </SwitchTransition>
+      </div>
       <Footer />
-    </>
+    </div>
   );
 }
 

--- a/frontend/src/styles/styles.css
+++ b/frontend/src/styles/styles.css
@@ -201,6 +201,28 @@ body.light-mode a:not([class*="Mui"]) {
   }
 }
 
+/* Sticky-footer scaffold: the shell is a full-viewport flex column, the
+   main area grows to absorb all spare height, so the footer is always
+   pinned to the bottom -- including while a route is still loading and the
+   page has rendered no height yet (previously the footer rode up under the
+   navbar mid-load). */
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  min-height: 100dvh;
+}
+
+.app-main {
+  flex: 1 0 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-main .page-anim {
+  flex: 1 0 auto;
+}
+
 /* Route page transitions: each page slides up into view on arrival and slides
    down out of view on departure (SwitchTransition mode="out-in"). */
 /* NOTE: `will-change` is applied ONLY during the active transition phases, not


### PR DESCRIPTION
## Problem

When a page loads (home and others), the routed page often has no rendered height yet, so the **footer rides all the way up to just under the navbar**, then snaps back down once content arrives. Looks broken mid-load.

## Fix

Sticky-footer flex scaffold:

- `.app-shell` — `min-height: 100vh/100dvh`, `display: flex; flex-direction: column`
- `.app-main` (wraps the route `SwitchTransition`) — `flex: 1 0 auto`
- `.page-anim` — `flex: 1 0 auto`

The main area always grows to absorb spare vertical space, so the footer is pinned to the bottom of the viewport even when the page content is empty/short during load. No more jump.

(App.js gains two wrapper `<div>`s; closing tags adjusted accordingly.)

## Testing

60 tests / 10 snapshots pass; eslint + prettier clean. Branched off latest master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)