### PR TITLE
feat(frontend): reset scroll to top on every route navigation

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -77,6 +77,18 @@ function AppLayout() {
     window.matchMedia("(prefers-reduced-motion: reduce)").matches;
   const timeout = reduceMotion ? 0 : { enter: 480, exit: 300 };
 
+  // Reset scroll to the top as the new page begins entering. With the
+  // out-in transition the old page fades out at its scroll position, then
+  // the incoming page mounts here at the top and fades in -- so navigating
+  // (e.g. Home -> Privacy Policy) never drops the user mid-page, and the
+  // existing fade/slide provides the smoothness rather than a jarring
+  // mid-scroll jump. Tied to the keyed CSSTransition (location.pathname),
+  // so in-page hash/anchor links are left alone.
+  const scrollToTopOnEnter = () => {
+    if (typeof window === "undefined") return;
+    window.scrollTo(0, 0);
+  };
+
   return (
     <div className="app-shell">
       {!hideNavbar && <Navbar />}
@@ -93,6 +105,7 @@ function AppLayout() {
             classNames="page"
             appear
             unmountOnExit
+            onEnter={scrollToTopOnEnter}
           >
             <div ref={nodeRef} className="page-anim">
               <Routes location={location}>


### PR DESCRIPTION
## Problem

Navigating between pages (e.g. Home → Privacy Policy) sometimes leaves the user partway down the new page — the browser keeps the previous page's scroll position.

## Fix

Reset scroll to the top from the route `CSSTransition`'s `onEnter` — i.e. exactly as the incoming page begins entering:

```js
onEnter={() => window.scrollTo(0, 0)}
```

With the existing out-in transition, the old page fades out at its scroll position, then the new page mounts at the top and fades in. No jarring mid-scroll jump — the fade/slide provides the smoothness, and the new page always starts at the top.

- Tied to the keyed transition (`location.pathname`), so **in-page hash/anchor links are left alone**.
- Also covers initial load (`appear`).

## Testing

60 tests / 10 snapshots pass; eslint + prettier clean. Branched off latest master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)